### PR TITLE
feat: implement `altair` spec

### DIFF
--- a/src/altair/block_processing.rs
+++ b/src/altair/block_processing.rs
@@ -225,7 +225,7 @@ pub fn process_deposit<
             state
                 .current_epoch_participation
                 .push(ParticipationFlags::default());
-            state.inactivity_scores.push(u64::default())
+            state.inactivity_scores.push(0)
         } else {
             return Err(invalid_operation_error(InvalidOperation::Deposit(
                 InvalidDeposit::InvalidSignature(deposit.data.signature.clone()),

--- a/src/altair/block_processing.rs
+++ b/src/altair/block_processing.rs
@@ -1,13 +1,30 @@
 // TODO remove once impl is added
 #![allow(dead_code)]
-
+#![allow(unused_mut)]
+#![allow(unused_variables)]
 use crate::altair as spec;
 
-use crate::state_transition::{Context, Result};
-use spec::{
-    process_block_header, process_eth1_data, process_operations, process_randao, Attestation,
-    BeaconBlock, BeaconState, Deposit, SyncAggregate,
+use crate::crypto::fast_aggregate_verify;
+use crate::domains::DomainType;
+use crate::primitives::{BlsPublicKey, ParticipationFlags, ValidatorIndex};
+use crate::signing::compute_signing_root;
+use crate::state_transition::{
+    invalid_operation_error, Context, InvalidAttestation, InvalidDeposit, InvalidOperation,
+    InvalidSyncAggregate, Result,
 };
+use spec::{
+    add_flag, compute_domain, compute_epoch_at_slot, decrease_balance,
+    get_attestation_participation_flag_indices, get_attesting_indices,
+    get_base_reward_per_increment, get_beacon_committee, get_beacon_proposer_index,
+    get_block_root_at_slot, get_committee_count_per_slot, get_current_epoch, get_domain,
+    get_indexed_attestation, get_previous_epoch, get_total_active_balance,
+    get_validator_from_deposit, has_flag, increase_balance, is_valid_indexed_attestation,
+    process_block_header, process_eth1_data, process_operations, process_randao, Attestation,
+    BeaconBlock, BeaconState, Deposit, DepositMessage, SyncAggregate,
+};
+use ssz_rs::prelude::*;
+use std::collections::HashSet;
+use std::iter::zip;
 
 pub fn process_attestation<
     const SLOTS_PER_HISTORICAL_ROOT: usize,
@@ -19,7 +36,7 @@ pub fn process_attestation<
     const MAX_VALIDATORS_PER_COMMITTEE: usize,
     const SYNC_COMMITTEE_SIZE: usize,
 >(
-    _state: &mut BeaconState<
+    state: &mut BeaconState<
         SLOTS_PER_HISTORICAL_ROOT,
         HISTORICAL_ROOTS_LIMIT,
         ETH1_DATA_VOTES_BOUND,
@@ -29,9 +46,123 @@ pub fn process_attestation<
         MAX_VALIDATORS_PER_COMMITTEE,
         SYNC_COMMITTEE_SIZE,
     >,
-    _attestation: &Attestation<MAX_VALIDATORS_PER_COMMITTEE>,
-    _context: &Context,
+    attestation: &Attestation<MAX_VALIDATORS_PER_COMMITTEE>,
+    context: &Context,
 ) -> Result<()> {
+    let data = &attestation.data;
+
+    let is_previous = data.target.epoch == get_previous_epoch(state, context);
+    let current_epoch = get_current_epoch(state, context);
+    let is_current = data.target.epoch == current_epoch;
+    let valid_target_epoch = is_previous || is_current;
+    if !valid_target_epoch {
+        return Err(invalid_operation_error(InvalidOperation::Attestation(
+            InvalidAttestation::InvalidTargetEpoch {
+                target: data.target.epoch,
+                current: current_epoch,
+            },
+        )));
+    }
+
+    let attestation_epoch = compute_epoch_at_slot(data.slot, context);
+    if data.target.epoch != attestation_epoch {
+        return Err(invalid_operation_error(InvalidOperation::Attestation(
+            InvalidAttestation::InvalidSlot {
+                slot: data.slot,
+                epoch: attestation_epoch,
+                target: data.target.epoch,
+            },
+        )));
+    }
+
+    let attestation_has_delay = data.slot + context.min_attestation_inclusion_delay <= state.slot;
+    let attestation_is_recent = state.slot <= data.slot + context.slots_per_epoch;
+    let attestation_is_timely = attestation_has_delay && attestation_is_recent;
+    if !attestation_is_timely {
+        return Err(invalid_operation_error(InvalidOperation::Attestation(
+            InvalidAttestation::NotTimely {
+                state_slot: state.slot,
+                attestation_slot: data.slot,
+                lower_bound: data.slot + context.slots_per_epoch,
+                upper_bound: data.slot + context.min_attestation_inclusion_delay,
+            },
+        )));
+    }
+
+    let committee_count = get_committee_count_per_slot(state, data.target.epoch, context);
+    if data.index >= committee_count {
+        return Err(invalid_operation_error(InvalidOperation::Attestation(
+            InvalidAttestation::InvalidIndex {
+                index: data.index,
+                upper_bound: committee_count,
+            },
+        )));
+    }
+
+    let committee = get_beacon_committee(state, data.slot, data.index, context)?;
+    if attestation.aggregation_bits.len() != committee.len() {
+        return Err(invalid_operation_error(InvalidOperation::Attestation(
+            InvalidAttestation::Bitfield {
+                expected_length: committee.len(),
+                length: attestation.aggregation_bits.len(),
+            },
+        )));
+    }
+
+    // Participation flag indices
+    let inclusion_delay = state.slot - data.slot;
+    let participation_flag_indices =
+        get_attestation_participation_flag_indices(state, data, inclusion_delay, context)?;
+
+    // Verify signature
+    let _ = is_valid_indexed_attestation(
+        state,
+        &mut get_indexed_attestation(state, attestation, context)?,
+        context,
+    )?;
+
+    // Update epoch participation flags
+    // @dev deviate from the order of the spec to avoid immutable borrow after mutable borrow
+    let attesting_indices =
+        get_attesting_indices(state, data, &attestation.aggregation_bits, context)?;
+
+    let epoch_participation = if is_current {
+        &mut state.current_epoch_participation
+    } else {
+        &mut state.previous_epoch_participation
+    };
+
+    let mut proposer_reward_numerator = 0;
+    // @dev this is where I start having trouble
+    // the `get_base_reward` below borrows state as immutable, but `epoch_participation` above borrows as mutable
+    for index in attesting_indices {
+        for (flag_index, weight) in crate::altair::PARTICIPATION_FLAG_WEIGHTS.iter().enumerate() {
+            // if flag_index in participation_flag_indices and not has_flag(epoch_participation[index], flag_index):
+            if participation_flag_indices.contains(&flag_index)
+                && !has_flag(epoch_participation[index], flag_index as u8)
+            {
+                epoch_participation[index] = add_flag(epoch_participation[index], flag_index as u8);
+                // @dev explicit import of `get_base_reward` to disambiguate instead of `spec` import
+                // also, this is where the issue with mutable vs immutable borrow occurs
+                /*
+                proposer_reward_numerator +=
+                    crate::altair::helpers::get_base_reward(state, index, context)? * weight;
+                */
+            }
+        }
+    }
+
+    // Reward proposer
+    let proposer_reward_denominator = (crate::altair::WEIGHT_DENOMINATOR
+        - crate::altair::PROPOSER_WEIGHT)
+        * crate::altair::WEIGHT_DENOMINATOR
+        / crate::altair::PROPOSER_WEIGHT;
+    let proposer_reward = proposer_reward_numerator / proposer_reward_denominator;
+    increase_balance(
+        state,
+        get_beacon_proposer_index(state, context)?,
+        proposer_reward,
+    );
     Ok(())
 }
 
@@ -45,7 +176,7 @@ pub fn process_deposit<
     const MAX_VALIDATORS_PER_COMMITTEE: usize,
     const SYNC_COMMITTEE_SIZE: usize,
 >(
-    _state: &mut BeaconState<
+    state: &mut BeaconState<
         SLOTS_PER_HISTORICAL_ROOT,
         HISTORICAL_ROOTS_LIMIT,
         ETH1_DATA_VOTES_BOUND,
@@ -55,9 +186,73 @@ pub fn process_deposit<
         MAX_VALIDATORS_PER_COMMITTEE,
         SYNC_COMMITTEE_SIZE,
     >,
-    _deposit: &mut Deposit,
-    _context: &Context,
+    deposit: &mut Deposit,
+    context: &Context,
 ) -> Result<()> {
+    let branch = deposit
+        .proof
+        .iter()
+        .map(|node| Node::from_bytes(node.as_ref().try_into().unwrap()))
+        .collect::<Vec<_>>();
+    let leaf = deposit.data.hash_tree_root()?;
+    let depth = crate::altair::DEPOSIT_CONTRACT_TREE_DEPTH + 1;
+    let index = state.eth1_deposit_index as usize;
+    let root = &state.eth1_data.deposit_root;
+    if !is_valid_merkle_branch(&leaf, branch.iter(), depth, index, root) {
+        return Err(invalid_operation_error(InvalidOperation::Deposit(
+            InvalidDeposit::InvalidProof {
+                leaf,
+                branch,
+                depth,
+                index,
+                root: *root,
+            },
+        )));
+    }
+
+    // NOTE: deviate from the order of the spec to avoid mutations
+    // that would need to be rolled back upon failure
+    let public_key = deposit.data.public_key.clone();
+    let amount = deposit.data.amount;
+    let validator_public_keys: HashSet<&BlsPublicKey> =
+        HashSet::from_iter(state.validators.iter().map(|v| &v.public_key));
+    if !validator_public_keys.contains(&public_key) {
+        let mut deposit_message = DepositMessage {
+            public_key: public_key.clone(),
+            withdrawal_credentials: deposit.data.withdrawal_credentials.clone(),
+            amount,
+        };
+        let domain = compute_domain(DomainType::Deposit, None, None, context)?;
+        let signing_root = compute_signing_root(&mut deposit_message, domain)?;
+        // Initialize validator if the deposit signature is valid
+        if public_key.verify_signature(signing_root.as_bytes(), &deposit.data.signature) {
+            state
+                .validators
+                .push(get_validator_from_deposit(deposit, context));
+            state.balances.push(amount);
+            state
+                .previous_epoch_participation
+                .push(ParticipationFlags::default());
+            state
+                .current_epoch_participation
+                .push(ParticipationFlags::default());
+            state.inactivity_scores.push(u64::default())
+        } else {
+            return Err(invalid_operation_error(InvalidOperation::Deposit(
+                InvalidDeposit::InvalidSignature(deposit.data.signature.clone()),
+            )));
+        }
+    } else {
+        let index = state
+            .validators
+            .iter()
+            .position(|v| v.public_key == public_key)
+            .unwrap();
+
+        increase_balance(state, index, amount);
+    }
+
+    state.eth1_deposit_index += 1;
     Ok(())
 }
 
@@ -71,7 +266,7 @@ pub fn process_sync_aggregate<
     const MAX_VALIDATORS_PER_COMMITTEE: usize,
     const SYNC_COMMITTEE_SIZE: usize,
 >(
-    _state: &mut BeaconState<
+    state: &mut BeaconState<
         SLOTS_PER_HISTORICAL_ROOT,
         HISTORICAL_ROOTS_LIMIT,
         ETH1_DATA_VOTES_BOUND,
@@ -81,9 +276,86 @@ pub fn process_sync_aggregate<
         MAX_VALIDATORS_PER_COMMITTEE,
         SYNC_COMMITTEE_SIZE,
     >,
-    _sync_aggregate: &SyncAggregate<SYNC_COMMITTEE_SIZE>,
-    _context: &Context,
+    sync_aggregate: &SyncAggregate<SYNC_COMMITTEE_SIZE>,
+    context: &Context,
 ) -> Result<()> {
+    // Verify sync committee aggregate signature signing over the previous slot block root
+    let committee_public_keys = &state.current_sync_committee.public_keys;
+    let participant_public_keys = zip(
+        committee_public_keys.iter(),
+        sync_aggregate.sync_committee_bits.iter(),
+    )
+    .filter_map(
+        |(public_key, bit)| {
+            if *bit {
+                Some(public_key)
+            } else {
+                None
+            }
+        },
+    )
+    .collect::<Vec<_>>();
+    let previous_slot = u64::max(state.slot, 1) - 1;
+    let domain = get_domain(
+        state,
+        DomainType::SyncCommittee,
+        Some(compute_epoch_at_slot(previous_slot, context)),
+        context,
+    )?;
+    let mut root_at_slot = *get_block_root_at_slot(state, previous_slot)?;
+    let signing_root = compute_signing_root(&mut root_at_slot, domain)?;
+    if !fast_aggregate_verify(
+        participant_public_keys.as_slice(),
+        signing_root.as_ref(),
+        &sync_aggregate.sync_committee_signature,
+    ) {
+        return Err(invalid_operation_error(InvalidOperation::SyncAggregate(
+            InvalidSyncAggregate::InvalidSignature {
+                signature: sync_aggregate.sync_committee_signature.clone(),
+                root: signing_root,
+            },
+        )));
+    }
+
+    // Compute participant and proposer rewards
+    let total_active_increments =
+        get_total_active_balance(state, context)? / context.effective_balance_increment;
+    let total_base_rewards =
+        get_base_reward_per_increment(state, context)? * total_active_increments;
+    let max_participant_rewards = total_base_rewards * crate::altair::SYNC_REWARD_WEIGHT
+        / crate::altair::WEIGHT_DENOMINATOR
+        / context.slots_per_epoch;
+    let participant_reward = max_participant_rewards / context.sync_committee_size as u64;
+    let proposer_reward = participant_reward * crate::altair::PROPOSER_WEIGHT
+        / (crate::altair::WEIGHT_DENOMINATOR - crate::altair::PROPOSER_WEIGHT);
+
+    // Apply participant and proposer rewards
+    // @dev usage of clone here
+    let mut all_public_keys = state.validators.iter().map(|v| v.public_key.clone());
+    let mut committee_indices: Vec<ValidatorIndex> = Vec::default();
+    for public_key in state.current_sync_committee.public_keys.iter() {
+        committee_indices.push(
+            all_public_keys
+                .position(|pk| pk == *public_key)
+                .expect("validator public_key should exist"),
+        );
+    }
+    for (participant_index, participation_bit) in zip(
+        committee_indices.iter(),
+        sync_aggregate.sync_committee_bits.iter(),
+    ) {
+        if *participation_bit {
+            increase_balance(state, *participant_index, participant_reward);
+            increase_balance(
+                state,
+                get_beacon_proposer_index(state, context)?,
+                proposer_reward,
+            );
+        } else {
+            decrease_balance(state, *participant_index, participant_reward);
+        }
+    }
+
     Ok(())
 }
 

--- a/src/altair/block_processing.rs
+++ b/src/altair/block_processing.rs
@@ -201,7 +201,7 @@ pub fn process_deposit<
 
     // NOTE: deviate from the order of the spec to avoid mutations
     // that would need to be rolled back upon failure
-    let public_key = deposit.data.public_key.clone();
+    let public_key = &deposit.data.public_key;
     let amount = deposit.data.amount;
     let validator_public_keys: HashSet<&BlsPublicKey> =
         HashSet::from_iter(state.validators.iter().map(|v| &v.public_key));

--- a/src/altair/block_processing.rs
+++ b/src/altair/block_processing.rs
@@ -1,7 +1,3 @@
-// TODO remove once impl is added
-#![allow(dead_code)]
-#![allow(unused_mut)]
-#![allow(unused_variables)]
 use crate::altair as spec;
 
 use crate::crypto::fast_aggregate_verify;
@@ -18,12 +14,14 @@ use spec::{
     get_base_reward_per_increment, get_beacon_committee, get_beacon_proposer_index,
     get_block_root_at_slot, get_committee_count_per_slot, get_current_epoch, get_domain,
     get_indexed_attestation, get_previous_epoch, get_total_active_balance,
-    get_validator_from_deposit, has_flag, increase_balance, is_valid_indexed_attestation,
-    process_block_header, process_eth1_data, process_operations, process_randao, Attestation,
-    BeaconBlock, BeaconState, Deposit, DepositMessage, SyncAggregate,
+    get_validator_from_deposit, has_flag, helpers::get_base_reward, increase_balance,
+    is_valid_indexed_attestation, process_block_header, process_eth1_data, process_operations,
+    process_randao, Attestation, BeaconBlock, BeaconState, Deposit, DepositMessage, SyncAggregate,
+    DEPOSIT_CONTRACT_TREE_DEPTH, PARTICIPATION_FLAG_WEIGHTS, PROPOSER_WEIGHT, SYNC_REWARD_WEIGHT,
+    WEIGHT_DENOMINATOR,
 };
 use ssz_rs::prelude::*;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::iter::zip;
 
 pub fn process_attestation<
@@ -126,37 +124,54 @@ pub fn process_attestation<
     let attesting_indices =
         get_attesting_indices(state, data, &attestation.aggregation_bits, context)?;
 
+    // @dev Create immutable reference to `{current_or_previous}_epoch_participation`
     let epoch_participation = if is_current {
-        &mut state.current_epoch_participation
+        &state.current_epoch_participation
     } else {
-        &mut state.previous_epoch_participation
+        &state.previous_epoch_participation
     };
 
     let mut proposer_reward_numerator = 0;
-    // @dev this is where I start having trouble
-    // the `get_base_reward` below borrows state as immutable, but `epoch_participation` above borrows as mutable
+    // @dev Use `participation_accumulator` to accumalate `index` and `ParticipationFlags` (via `add_flags`).
+    // Then, use this HashMap later in `set_epoch_participation` to achieve overwrite of the
+    // corresponding `{current_or_previous}_epoch_participation`'s flag.
+    // Replacement for the python code below, which would occur inside the loop's `if` statement:
+    // epoch_participation[index] = add_flag(epoch_participation[index], flag_index as u8);
+    let mut participation_accumulator = HashMap::<usize, ParticipationFlags>::default();
     for index in attesting_indices {
-        for (flag_index, weight) in crate::altair::PARTICIPATION_FLAG_WEIGHTS.iter().enumerate() {
-            // if flag_index in participation_flag_indices and not has_flag(epoch_participation[index], flag_index):
+        for (flag_index, weight) in PARTICIPATION_FLAG_WEIGHTS.iter().enumerate() {
             if participation_flag_indices.contains(&flag_index)
                 && !has_flag(epoch_participation[index], flag_index as u8)
             {
-                epoch_participation[index] = add_flag(epoch_participation[index], flag_index as u8);
+                participation_accumulator.insert(
+                    index,
+                    add_flag(epoch_participation[index], flag_index as u8),
+                );
+                // epoch_participation[index] = add_flag(epoch_participation[index], flag_index as u8);
                 // @dev explicit import of `get_base_reward` to disambiguate instead of `spec` import
                 // also, this is where the issue with mutable vs immutable borrow occurs
-                /*
-                proposer_reward_numerator +=
-                    crate::altair::helpers::get_base_reward(state, index, context)? * weight;
-                */
+
+                proposer_reward_numerator += get_base_reward(state, index, context)? * weight;
             }
         }
     }
 
+    // @dev Create mutable reference to `{current_or_previous}_epoch_participation`
+    let set_epoch_participation = if is_current {
+        &mut state.current_epoch_participation
+    } else {
+        &mut state.previous_epoch_participation
+    };
+    // @dev Update flags in `set_epoch_participation` to corresponding values in `participation_accumulator`
+    for i in 0..set_epoch_participation.len() {
+        set_epoch_participation[i] = *participation_accumulator
+            .get(&i)
+            .expect("index in epoch participation should exist");
+    }
+
     // Reward proposer
-    let proposer_reward_denominator = (crate::altair::WEIGHT_DENOMINATOR
-        - crate::altair::PROPOSER_WEIGHT)
-        * crate::altair::WEIGHT_DENOMINATOR
-        / crate::altair::PROPOSER_WEIGHT;
+    let proposer_reward_denominator =
+        (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT) * WEIGHT_DENOMINATOR / PROPOSER_WEIGHT;
     let proposer_reward = proposer_reward_numerator / proposer_reward_denominator;
     increase_balance(
         state,
@@ -195,7 +210,7 @@ pub fn process_deposit<
         .map(|node| Node::from_bytes(node.as_ref().try_into().unwrap()))
         .collect::<Vec<_>>();
     let leaf = deposit.data.hash_tree_root()?;
-    let depth = crate::altair::DEPOSIT_CONTRACT_TREE_DEPTH + 1;
+    let depth = DEPOSIT_CONTRACT_TREE_DEPTH + 1;
     let index = state.eth1_deposit_index as usize;
     let root = &state.eth1_data.deposit_root;
     if !is_valid_merkle_branch(&leaf, branch.iter(), depth, index, root) {
@@ -322,21 +337,24 @@ pub fn process_sync_aggregate<
         get_total_active_balance(state, context)? / context.effective_balance_increment;
     let total_base_rewards =
         get_base_reward_per_increment(state, context)? * total_active_increments;
-    let max_participant_rewards = total_base_rewards * crate::altair::SYNC_REWARD_WEIGHT
-        / crate::altair::WEIGHT_DENOMINATOR
-        / context.slots_per_epoch;
+    let max_participant_rewards =
+        total_base_rewards * SYNC_REWARD_WEIGHT / WEIGHT_DENOMINATOR / context.slots_per_epoch;
     let participant_reward = max_participant_rewards / context.sync_committee_size as u64;
-    let proposer_reward = participant_reward * crate::altair::PROPOSER_WEIGHT
-        / (crate::altair::WEIGHT_DENOMINATOR - crate::altair::PROPOSER_WEIGHT);
+    let proposer_reward =
+        participant_reward * PROPOSER_WEIGHT / (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT);
 
     // Apply participant and proposer rewards
-    // @dev usage of clone here
-    let mut all_public_keys = state.validators.iter().map(|v| v.public_key.clone());
+    let all_public_keys = state
+        .validators
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (&v.public_key, i))
+        .collect::<HashMap<&BlsPublicKey, usize>>();
     let mut committee_indices: Vec<ValidatorIndex> = Vec::default();
     for public_key in state.current_sync_committee.public_keys.iter() {
         committee_indices.push(
-            all_public_keys
-                .position(|pk| pk == *public_key)
+            *all_public_keys
+                .get(public_key)
                 .expect("validator public_key should exist"),
         );
     }

--- a/src/altair/block_processing.rs
+++ b/src/altair/block_processing.rs
@@ -205,7 +205,7 @@ pub fn process_deposit<
     let amount = deposit.data.amount;
     let validator_public_keys: HashSet<&BlsPublicKey> =
         HashSet::from_iter(state.validators.iter().map(|v| &v.public_key));
-    if !validator_public_keys.contains(&public_key) {
+    if !validator_public_keys.contains(public_key) {
         let mut deposit_message = DepositMessage {
             public_key: public_key.clone(),
             withdrawal_credentials: deposit.data.withdrawal_credentials.clone(),

--- a/src/altair/epoch_processing.rs
+++ b/src/altair/epoch_processing.rs
@@ -1,11 +1,17 @@
 use crate::altair as spec;
 
+use crate::primitives::{ParticipationFlags, GENESIS_EPOCH};
 use crate::state_transition::{Context, Result};
 use spec::{
-    process_effective_balance_updates, process_eth1_data_reset, process_historical_roots_update,
-    process_randao_mixes_reset, process_registry_updates, process_slashings,
-    process_slashings_reset, BeaconState,
+    decrease_balance, get_current_epoch, get_eligible_validator_indices, get_flag_index_deltas,
+    get_inactivity_penalty_deltas, get_next_sync_committee, get_previous_epoch,
+    get_total_active_balance, get_total_balance, get_unslashed_participating_indices,
+    increase_balance, is_in_inactivity_leak, process_effective_balance_updates,
+    process_eth1_data_reset, process_historical_roots_update, process_randao_mixes_reset,
+    process_registry_updates, process_slashings, process_slashings_reset,
+    weigh_justification_and_finalization, BeaconState,
 };
+use std::mem;
 
 pub fn process_justification_and_finalization<
     const SLOTS_PER_HISTORICAL_ROOT: usize,
@@ -17,7 +23,7 @@ pub fn process_justification_and_finalization<
     const MAX_VALIDATORS_PER_COMMITTEE: usize,
     const SYNC_COMMITTEE_SIZE: usize,
 >(
-    _state: &mut BeaconState<
+    state: &mut BeaconState<
         SLOTS_PER_HISTORICAL_ROOT,
         HISTORICAL_ROOTS_LIMIT,
         ETH1_DATA_VOTES_BOUND,
@@ -27,9 +33,37 @@ pub fn process_justification_and_finalization<
         MAX_VALIDATORS_PER_COMMITTEE,
         SYNC_COMMITTEE_SIZE,
     >,
-    _context: &Context,
+    context: &Context,
 ) -> Result<()> {
-    Ok(())
+    // Initial FFG checkpoint values have a `0x00` stub for `root`.
+    // Skip FFG updates in the first two epochs to avoid corner cases that might result in modifying this stub.
+    let current_epoch = get_current_epoch(state, context);
+    if current_epoch <= GENESIS_EPOCH + 1 {
+        return Ok(());
+    }
+
+    let previous_indices = get_unslashed_participating_indices(
+        state,
+        crate::altair::TIMELY_TARGET_FLAG_INDEX,
+        get_previous_epoch(state, context),
+        context,
+    )?;
+    let current_indices = get_unslashed_participating_indices(
+        state,
+        crate::altair::TIMELY_TARGET_FLAG_INDEX,
+        get_previous_epoch(state, context),
+        context,
+    )?;
+    let total_active_balance = get_total_active_balance(state, context)?;
+    let previous_target_balance = get_total_balance(state, &previous_indices, context)?;
+    let current_target_balance = get_total_balance(state, &current_indices, context)?;
+    weigh_justification_and_finalization(
+        state,
+        total_active_balance,
+        previous_target_balance,
+        current_target_balance,
+        context,
+    )
 }
 
 pub fn process_inactivity_updates<
@@ -42,7 +76,7 @@ pub fn process_inactivity_updates<
     const MAX_VALIDATORS_PER_COMMITTEE: usize,
     const SYNC_COMMITTEE_SIZE: usize,
 >(
-    _state: &mut BeaconState<
+    state: &mut BeaconState<
         SLOTS_PER_HISTORICAL_ROOT,
         HISTORICAL_ROOTS_LIMIT,
         ETH1_DATA_VOTES_BOUND,
@@ -52,8 +86,35 @@ pub fn process_inactivity_updates<
         MAX_VALIDATORS_PER_COMMITTEE,
         SYNC_COMMITTEE_SIZE,
     >,
-    _context: &Context,
+    context: &Context,
 ) -> Result<()> {
+    // Skip the genesis epoch as score updates are based on the previous epoch participation
+    let current_epoch = get_current_epoch(state, context);
+    if current_epoch == GENESIS_EPOCH {
+        return Ok(());
+    }
+
+    let eligible_validator_indices =
+        get_eligible_validator_indices(state, context).collect::<Vec<_>>();
+    for index in eligible_validator_indices {
+        // Increase the inactivity score of inactive validators
+        if get_unslashed_participating_indices(
+            state,
+            crate::altair::TIMELY_TARGET_FLAG_INDEX,
+            get_previous_epoch(state, context),
+            context,
+        )?
+        .contains(&index)
+        {
+            state.inactivity_scores[index] -= u64::min(1, state.inactivity_scores[index]);
+        } else {
+            state.inactivity_scores[index] += context.inactivity_score_bias;
+        }
+        // Decrease the inactivity score of all eligible validators during a leak-free epoch
+        if !is_in_inactivity_leak(state, context) {
+            state.inactivity_scores[index] -= u64::min(1, state.inactivity_scores[index]);
+        }
+    }
     Ok(())
 }
 
@@ -67,7 +128,7 @@ pub fn process_rewards_and_penalties<
     const MAX_VALIDATORS_PER_COMMITTEE: usize,
     const SYNC_COMMITTEE_SIZE: usize,
 >(
-    _state: &mut BeaconState<
+    state: &mut BeaconState<
         SLOTS_PER_HISTORICAL_ROOT,
         HISTORICAL_ROOTS_LIMIT,
         ETH1_DATA_VOTES_BOUND,
@@ -77,8 +138,27 @@ pub fn process_rewards_and_penalties<
         MAX_VALIDATORS_PER_COMMITTEE,
         SYNC_COMMITTEE_SIZE,
     >,
-    _context: &Context,
+    context: &Context,
 ) -> Result<()> {
+    // No rewards are applied at the end of `GENESIS_EPOCH` because rewards are for work done in the previous epoch
+    let current_epoch = get_current_epoch(state, context);
+    if current_epoch == GENESIS_EPOCH {
+        return Ok(());
+    }
+
+    let mut deltas = Vec::new();
+    for flag_index in 0..crate::altair::PARTICIPATION_FLAG_WEIGHTS.len() {
+        let flag_index_delta = get_flag_index_deltas(state, flag_index, context)?;
+        deltas.push(flag_index_delta);
+    }
+    let mut inactivity_penalty_deltas = vec![get_inactivity_penalty_deltas(state, context)?];
+    deltas.append(&mut inactivity_penalty_deltas);
+    for (rewards, penalties) in deltas.iter() {
+        for index in 0..state.validators.len() {
+            increase_balance(state, index, rewards[index]);
+            decrease_balance(state, index, penalties[index]);
+        }
+    }
     Ok(())
 }
 
@@ -92,7 +172,7 @@ pub fn process_participation_flag_updates<
     const MAX_VALIDATORS_PER_COMMITTEE: usize,
     const SYNC_COMMITTEE_SIZE: usize,
 >(
-    _state: &mut BeaconState<
+    state: &mut BeaconState<
         SLOTS_PER_HISTORICAL_ROOT,
         HISTORICAL_ROOTS_LIMIT,
         ETH1_DATA_VOTES_BOUND,
@@ -102,8 +182,15 @@ pub fn process_participation_flag_updates<
         MAX_VALIDATORS_PER_COMMITTEE,
         SYNC_COMMITTEE_SIZE,
     >,
-    _context: &Context,
 ) -> Result<()> {
+    let current_participation = mem::take(&mut state.current_epoch_participation);
+    state.previous_epoch_participation = current_participation;
+    // @dev intention is to set `rotate_participation` to a `List` of u8 values of length state's validators
+    // But, if `current_epoch_participation` is of length `VALIDATOR_REGISTRY_LIMIT` -- does this pose an issue?
+    let rotate_participation = vec![ParticipationFlags::default(); state.validators.len()];
+    state.current_epoch_participation = rotate_participation
+        .try_into()
+        .expect("should convert from Vec to List");
     Ok(())
 }
 
@@ -117,7 +204,7 @@ pub fn process_sync_committee_updates<
     const MAX_VALIDATORS_PER_COMMITTEE: usize,
     const SYNC_COMMITTEE_SIZE: usize,
 >(
-    _state: &mut BeaconState<
+    state: &mut BeaconState<
         SLOTS_PER_HISTORICAL_ROOT,
         HISTORICAL_ROOTS_LIMIT,
         ETH1_DATA_VOTES_BOUND,
@@ -127,8 +214,14 @@ pub fn process_sync_committee_updates<
         MAX_VALIDATORS_PER_COMMITTEE,
         SYNC_COMMITTEE_SIZE,
     >,
-    _context: &Context,
+    context: &Context,
 ) -> Result<()> {
+    let next_sync_committee = mem::take(&mut state.next_sync_committee);
+    let next_epoch = get_current_epoch(state, context) + 1;
+    if next_epoch % context.epochs_per_sync_committee_period == 0 {
+        state.current_sync_committee = next_sync_committee;
+        state.next_sync_committee = get_next_sync_committee(state, context)?;
+    }
     Ok(())
 }
 
@@ -164,7 +257,7 @@ pub fn process_epoch<
     process_slashings_reset(state, context);
     process_randao_mixes_reset(state, context);
     process_historical_roots_update(state, context)?;
-    process_participation_flag_updates(state, context)?;
+    process_participation_flag_updates(state)?;
     process_sync_committee_updates(state, context)?;
     Ok(())
 }

--- a/src/altair/epoch_processing.rs
+++ b/src/altair/epoch_processing.rs
@@ -9,8 +9,7 @@ use spec::{
     increase_balance, is_in_inactivity_leak, process_effective_balance_updates,
     process_eth1_data_reset, process_historical_roots_update, process_randao_mixes_reset,
     process_registry_updates, process_slashings, process_slashings_reset,
-    weigh_justification_and_finalization, BeaconState, PARTICIPATION_FLAG_WEIGHTS,
-    TIMELY_TARGET_FLAG_INDEX,
+    weigh_justification_and_finalization, BeaconState,
 };
 use std::mem;
 
@@ -45,13 +44,13 @@ pub fn process_justification_and_finalization<
 
     let previous_indices = get_unslashed_participating_indices(
         state,
-        TIMELY_TARGET_FLAG_INDEX,
+        crate::altair::TIMELY_TARGET_FLAG_INDEX,
         get_previous_epoch(state, context),
         context,
     )?;
     let current_indices = get_unslashed_participating_indices(
         state,
-        TIMELY_TARGET_FLAG_INDEX,
+        crate::altair::TIMELY_TARGET_FLAG_INDEX,
         get_previous_epoch(state, context),
         context,
     )?;
@@ -101,7 +100,7 @@ pub fn process_inactivity_updates<
         // Increase the inactivity score of inactive validators
         if get_unslashed_participating_indices(
             state,
-            TIMELY_TARGET_FLAG_INDEX,
+            crate::altair::TIMELY_TARGET_FLAG_INDEX,
             get_previous_epoch(state, context),
             context,
         )?
@@ -148,11 +147,12 @@ pub fn process_rewards_and_penalties<
     }
 
     let mut deltas = Vec::new();
-    for flag_index in 0..PARTICIPATION_FLAG_WEIGHTS.len() {
+    for flag_index in 0..crate::altair::PARTICIPATION_FLAG_WEIGHTS.len() {
         let flag_index_delta = get_flag_index_deltas(state, flag_index, context)?;
         deltas.push(flag_index_delta);
     }
-    deltas.push(get_inactivity_penalty_deltas(state, context)?);
+    let mut inactivity_penalty_deltas = vec![get_inactivity_penalty_deltas(state, context)?];
+    deltas.append(&mut inactivity_penalty_deltas);
     for (rewards, penalties) in deltas.iter() {
         for index in 0..state.validators.len() {
             increase_balance(state, index, rewards[index]);
@@ -185,6 +185,8 @@ pub fn process_participation_flag_updates<
 ) -> Result<()> {
     let current_participation = mem::take(&mut state.current_epoch_participation);
     state.previous_epoch_participation = current_participation;
+    // @dev intention is to set `rotate_participation` to a `List` of u8 values of length state's validators
+    // But, if `current_epoch_participation` is of length `VALIDATOR_REGISTRY_LIMIT` -- does this pose an issue?
     let rotate_participation = vec![ParticipationFlags::default(); state.validators.len()];
     state.current_epoch_participation = rotate_participation
         .try_into()

--- a/src/altair/helpers.rs
+++ b/src/altair/helpers.rs
@@ -450,7 +450,6 @@ pub fn slash_validator<
 
     let whistleblower_reward =
         state.validators[slashed_index].effective_balance / context.whistleblower_reward_quotient;
-    // NOTE: direct imports to simplify forward code gen of these constants
     let proposer_reward_scaling_factor = PROPOSER_WEIGHT / WEIGHT_DENOMINATOR;
     let proposer_reward = whistleblower_reward * proposer_reward_scaling_factor;
     increase_balance(state, proposer_index, proposer_reward);

--- a/src/altair/helpers.rs
+++ b/src/altair/helpers.rs
@@ -274,7 +274,7 @@ pub fn get_attestation_participation_flag_indices<
         MAX_VALIDATORS_PER_COMMITTEE,
         SYNC_COMMITTEE_SIZE,
     >,
-    data: AttestationData,
+    data: &AttestationData,
     inclusion_delay: u64,
     context: &Context,
 ) -> Result<Vec<usize>> {
@@ -291,7 +291,7 @@ pub fn get_attestation_participation_flag_indices<
         return Err(invalid_operation_error(InvalidOperation::Attestation(
             InvalidAttestation::InvalidSource {
                 expected: justified_checkpoint.clone(),
-                source_checkpoint: data.source,
+                source_checkpoint: data.source.clone(),
                 current: get_current_epoch(state, context),
             },
         )));

--- a/src/altair/helpers.rs
+++ b/src/altair/helpers.rs
@@ -223,7 +223,7 @@ pub fn get_unslashed_participating_indices<
     let active_validator_indices = get_active_validator_indices(state, epoch);
     let participating_indices = active_validator_indices
         .iter()
-        .filter_map(|&i| {
+        .filter(|&i| {
             if is_current {
                 if has_flag(state.current_epoch_participation[i], flag_index as u8) {
                     Some(i)

--- a/src/altair/helpers.rs
+++ b/src/altair/helpers.rs
@@ -1,6 +1,6 @@
 use crate::altair as spec;
 
-use crate::crypto::{eth_aggregate_pubkeys, hash};
+use crate::crypto::{eth_aggregate_public_keys, hash};
 use crate::domains::DomainType;
 use crate::primitives::{Epoch, Gwei, ParticipationFlags, ValidatorIndex};
 use crate::state_transition::{
@@ -60,7 +60,6 @@ pub fn get_next_sync_committee_indices<
     let seed = get_seed(state, epoch, DomainType::SyncCommittee, context);
     let i = 0;
     let mut sync_committee_indices = Vec::<ValidatorIndex>::new();
-    // @dev need to validate this is correct for `hash`
     let mut hash_input = [0u8; 40];
     hash_input[..32].copy_from_slice(seed.as_ref());
     while sync_committee_indices.len() < context.sync_committee_size {
@@ -120,13 +119,9 @@ pub fn get_next_sync_committee<
             }
         })
         .collect::<Vec<_>>();
-    // @dev not sure if the impl of `eth_aggregate_pubkeys` is needed or correct
-    // also, not sure if `expect` is desired here
-    let aggregate_public_key = eth_aggregate_pubkeys(&public_keys)
+    // @dev WIP fixing error return issue if using `?` instead of `expect` as well as `clone`
+    let aggregate_public_key = eth_aggregate_public_keys(&public_keys)
         .expect("validator public_keys should be aggregated into aggregate_public_key");
-
-    // @dev ran into trouble here so just cloned() the validator's public_key
-    // couldn't figure out how to properly coerce/convert `public_keys` Vec to ssz_rs::Vector
     let pks_vector =
         Vector::<_, SYNC_COMMITTEE_SIZE>::from_iter(public_keys.iter().map(|&pk| pk.clone()));
 
@@ -303,13 +298,13 @@ pub fn get_attestation_participation_flag_indices<
 
     let mut participation_flag_indices = Vec::new();
     if is_matching_source && inclusion_delay <= context.slots_per_epoch.integer_sqrt() {
-        participation_flag_indices.push(crate::altair::TIMELY_SOURCE_FLAG_INDEX);
+        participation_flag_indices.push(TIMELY_SOURCE_FLAG_INDEX);
     }
     if is_matching_target && inclusion_delay <= context.slots_per_epoch {
-        participation_flag_indices.push(crate::altair::TIMELY_TARGET_FLAG_INDEX);
+        participation_flag_indices.push(TIMELY_TARGET_FLAG_INDEX);
     }
     if is_matching_head && inclusion_delay == context.min_attestation_inclusion_delay {
-        participation_flag_indices.push(crate::altair::TIMELY_HEAD_FLAG_INDEX);
+        participation_flag_indices.push(TIMELY_HEAD_FLAG_INDEX);
     }
 
     Ok(participation_flag_indices)
@@ -345,7 +340,7 @@ pub fn get_flag_index_deltas<
     let previous_epoch = get_previous_epoch(state, context);
     let unslashed_participating_indices =
         get_unslashed_participating_indices(state, flag_index, previous_epoch, context)?;
-    let weight = crate::altair::PARTICIPATION_FLAG_WEIGHTS[flag_index];
+    let weight = PARTICIPATION_FLAG_WEIGHTS[flag_index];
     let unslashed_participating_balance =
         get_total_balance(state, &unslashed_participating_indices, context)?;
     let unslashed_participating_increments =
@@ -357,10 +352,9 @@ pub fn get_flag_index_deltas<
         if unslashed_participating_indices.contains(&index) {
             if !is_in_inactivity_leak(state, context) {
                 let reward_numerator = base_reward * weight * unslashed_participating_increments;
-                rewards[index] +=
-                    reward_numerator / (active_increments * crate::altair::WEIGHT_DENOMINATOR);
-            } else if flag_index != crate::altair::TIMELY_HEAD_FLAG_INDEX {
-                penalties[index] += base_reward * weight / crate::altair::WEIGHT_DENOMINATOR;
+                rewards[index] += reward_numerator / (active_increments * WEIGHT_DENOMINATOR);
+            } else if flag_index != TIMELY_HEAD_FLAG_INDEX {
+                penalties[index] += base_reward * weight / WEIGHT_DENOMINATOR;
             }
         }
     }

--- a/src/altair/helpers.rs
+++ b/src/altair/helpers.rs
@@ -1,6 +1,6 @@
 use crate::altair as spec;
 
-use crate::crypto::{eth_aggregate_public_keys, hash};
+use crate::crypto::{eth_aggregate_pubkeys, hash};
 use crate::domains::DomainType;
 use crate::primitives::{Epoch, Gwei, ParticipationFlags, ValidatorIndex};
 use crate::state_transition::{
@@ -60,6 +60,7 @@ pub fn get_next_sync_committee_indices<
     let seed = get_seed(state, epoch, DomainType::SyncCommittee, context);
     let i = 0;
     let mut sync_committee_indices = Vec::<ValidatorIndex>::new();
+    // @dev need to validate this is correct for `hash`
     let mut hash_input = [0u8; 40];
     hash_input[..32].copy_from_slice(seed.as_ref());
     while sync_committee_indices.len() < context.sync_committee_size {
@@ -119,9 +120,13 @@ pub fn get_next_sync_committee<
             }
         })
         .collect::<Vec<_>>();
-    // @dev WIP fixing error return issue if using `?` instead of `expect` as well as `clone`
-    let aggregate_public_key = eth_aggregate_public_keys(&public_keys)
+    // @dev not sure if the impl of `eth_aggregate_pubkeys` is needed or correct
+    // also, not sure if `expect` is desired here
+    let aggregate_public_key = eth_aggregate_pubkeys(&public_keys)
         .expect("validator public_keys should be aggregated into aggregate_public_key");
+
+    // @dev ran into trouble here so just cloned() the validator's public_key
+    // couldn't figure out how to properly coerce/convert `public_keys` Vec to ssz_rs::Vector
     let pks_vector =
         Vector::<_, SYNC_COMMITTEE_SIZE>::from_iter(public_keys.iter().map(|&pk| pk.clone()));
 
@@ -298,13 +303,13 @@ pub fn get_attestation_participation_flag_indices<
 
     let mut participation_flag_indices = Vec::new();
     if is_matching_source && inclusion_delay <= context.slots_per_epoch.integer_sqrt() {
-        participation_flag_indices.push(TIMELY_SOURCE_FLAG_INDEX);
+        participation_flag_indices.push(crate::altair::TIMELY_SOURCE_FLAG_INDEX);
     }
     if is_matching_target && inclusion_delay <= context.slots_per_epoch {
-        participation_flag_indices.push(TIMELY_TARGET_FLAG_INDEX);
+        participation_flag_indices.push(crate::altair::TIMELY_TARGET_FLAG_INDEX);
     }
     if is_matching_head && inclusion_delay == context.min_attestation_inclusion_delay {
-        participation_flag_indices.push(TIMELY_HEAD_FLAG_INDEX);
+        participation_flag_indices.push(crate::altair::TIMELY_HEAD_FLAG_INDEX);
     }
 
     Ok(participation_flag_indices)
@@ -340,7 +345,7 @@ pub fn get_flag_index_deltas<
     let previous_epoch = get_previous_epoch(state, context);
     let unslashed_participating_indices =
         get_unslashed_participating_indices(state, flag_index, previous_epoch, context)?;
-    let weight = PARTICIPATION_FLAG_WEIGHTS[flag_index];
+    let weight = crate::altair::PARTICIPATION_FLAG_WEIGHTS[flag_index];
     let unslashed_participating_balance =
         get_total_balance(state, &unslashed_participating_indices, context)?;
     let unslashed_participating_increments =
@@ -352,9 +357,10 @@ pub fn get_flag_index_deltas<
         if unslashed_participating_indices.contains(&index) {
             if !is_in_inactivity_leak(state, context) {
                 let reward_numerator = base_reward * weight * unslashed_participating_increments;
-                rewards[index] += reward_numerator / (active_increments * WEIGHT_DENOMINATOR);
-            } else if flag_index != TIMELY_HEAD_FLAG_INDEX {
-                penalties[index] += base_reward * weight / WEIGHT_DENOMINATOR;
+                rewards[index] +=
+                    reward_numerator / (active_increments * crate::altair::WEIGHT_DENOMINATOR);
+            } else if flag_index != crate::altair::TIMELY_HEAD_FLAG_INDEX {
+                penalties[index] += base_reward * weight / crate::altair::WEIGHT_DENOMINATOR;
             }
         }
     }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -86,7 +86,9 @@ pub fn fast_aggregate_verify(pks: &[&PublicKey], msg: &[u8], signature: &Signatu
     res == BLST_ERROR::BLST_SUCCESS
 }
 
-pub fn eth_aggregate_public_keys(pks: &[&PublicKey]) -> Result<PublicKey, Error> {
+pub fn eth_aggregate_public_keys<const N: usize>(
+    pks: &Vector<PublicKey, N>,
+) -> Result<PublicKey, Error> {
     // Return the aggregate public key for the public keys in `pks`
     if pks.is_empty() {
         return Err(Error::EmptyInput);

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -87,7 +87,7 @@ pub fn fast_aggregate_verify(pks: &[&PublicKey], msg: &[u8], signature: &Signatu
 }
 
 pub fn eth_aggregate_public_keys<const N: usize>(
-    pks: &Vector<PublicKey, N>,
+    pks: &[PublicKey],
 ) -> Result<PublicKey, Error> {
     // Return the aggregate public key for the public keys in `pks`
     if pks.is_empty() {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -86,6 +86,17 @@ pub fn fast_aggregate_verify(pks: &[&PublicKey], msg: &[u8], signature: &Signatu
     res == BLST_ERROR::BLST_SUCCESS
 }
 
+// @dev not sure if this is the correct impl
+pub fn eth_aggregate_pubkeys(pks: &[&PublicKey]) -> Result<PublicKey, Error> {
+    // Return the aggregate public key for the public keys in `pks`
+    if pks.is_empty() {
+        return Err(Error::EmptyInput);
+    }
+    let v: Vec<&blst_core::PublicKey> = pks.iter().map(|pk| &pk.0).collect();
+    
+    blst_core::AggregatePublicKey::aggregate(&v, true).map(|agg_pk| PublicKey(agg_pk.to_public_key())).map_err(|e| BLSTError::from(e).into())
+}
+
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "String"))]

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -86,8 +86,7 @@ pub fn fast_aggregate_verify(pks: &[&PublicKey], msg: &[u8], signature: &Signatu
     res == BLST_ERROR::BLST_SUCCESS
 }
 
-// @dev not sure if this is the correct impl
-pub fn eth_aggregate_pubkeys(pks: &[&PublicKey]) -> Result<PublicKey, Error> {
+pub fn eth_aggregate_public_keys(pks: &[&PublicKey]) -> Result<PublicKey, Error> {
     // Return the aggregate public key for the public keys in `pks`
     if pks.is_empty() {
         return Err(Error::EmptyInput);

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -86,7 +86,8 @@ pub fn fast_aggregate_verify(pks: &[&PublicKey], msg: &[u8], signature: &Signatu
     res == BLST_ERROR::BLST_SUCCESS
 }
 
-pub fn eth_aggregate_public_keys(pks: &[&PublicKey]) -> Result<PublicKey, Error> {
+// @dev not sure if this is the correct impl
+pub fn eth_aggregate_pubkeys(pks: &[&PublicKey]) -> Result<PublicKey, Error> {
     // Return the aggregate public key for the public keys in `pks`
     if pks.is_empty() {
         return Err(Error::EmptyInput);

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -93,8 +93,10 @@ pub fn eth_aggregate_pubkeys(pks: &[&PublicKey]) -> Result<PublicKey, Error> {
         return Err(Error::EmptyInput);
     }
     let v: Vec<&blst_core::PublicKey> = pks.iter().map(|pk| &pk.0).collect();
-    
-    blst_core::AggregatePublicKey::aggregate(&v, true).map(|agg_pk| PublicKey(agg_pk.to_public_key())).map_err(|e| BLSTError::from(e).into())
+
+    blst_core::AggregatePublicKey::aggregate(&v, true)
+        .map(|agg_pk| PublicKey(agg_pk.to_public_key()))
+        .map_err(|e| BLSTError::from(e).into())
 }
 
 #[derive(Clone, Default)]

--- a/src/state_transition/error.rs
+++ b/src/state_transition/error.rs
@@ -1,7 +1,5 @@
 use crate::phase0::{AttestationData, BeaconBlockHeader, Checkpoint};
-use crate::primitives::{
-    BlsPublicKey, BlsSignature, Bytes32, Epoch, Hash32, Root, Slot, ValidatorIndex,
-};
+use crate::primitives::{BlsSignature, Bytes32, Epoch, Hash32, Root, Slot, ValidatorIndex};
 use crate::state_transition::{ForkSchedule, Forks};
 use ssz_rs::prelude::*;
 use thiserror::Error;
@@ -18,8 +16,6 @@ pub enum Error {
     OutOfBounds { requested: usize, bound: usize },
     #[error("invalid signature")]
     InvalidSignature,
-    #[error("invalid public key")]
-    InvalidPublicKey,
     #[error("collection cannot be empty")]
     CollectionCannotBeEmpty,
     #[error("given index {index} is greater than the total amount of indices {total}")]
@@ -90,8 +86,6 @@ pub enum InvalidOperation {
     VoluntaryExit(#[from] InvalidVoluntaryExit),
     #[error("invalid sync aggregate: {0}")]
     SyncAggregate(#[from] InvalidSyncAggregate),
-    #[error("invalid sync committee: {0}")]
-    SyncCommittee(#[from] InvalidSyncCommittee),
     #[error("invalid execution payload: {0}")]
     ExecutionPayload(#[from] InvalidExecutionPayload),
 }
@@ -220,12 +214,6 @@ pub enum InvalidVoluntaryExit {
 pub enum InvalidSyncAggregate {
     #[error("invalid sync committee aggregate signature {signature} signing over previous slot block root {root}")]
     InvalidSignature { signature: BlsSignature, root: Node },
-}
-
-#[derive(Debug, Error)]
-pub enum InvalidSyncCommittee {
-    #[error("invalid aggregated public key for sync committee")]
-    InvalidPublicKey,
 }
 
 #[derive(Debug, Error)]

--- a/src/state_transition/error.rs
+++ b/src/state_transition/error.rs
@@ -212,7 +212,10 @@ pub enum InvalidVoluntaryExit {
 
 #[derive(Debug, Error)]
 #[error("TODO: fill out")]
-pub enum InvalidSyncAggregate {}
+pub enum InvalidSyncAggregate {
+    #[error("invalid sync committee aggregate signature {signature} signing over previous slot block root {root}")]
+    InvalidSignature { signature: BlsSignature, root: Node },
+}
 
 #[derive(Debug, Error)]
 pub enum InvalidExecutionPayload {

--- a/src/state_transition/error.rs
+++ b/src/state_transition/error.rs
@@ -1,3 +1,4 @@
+use crate::crypto::Error as CryptoError;
 use crate::phase0::{AttestationData, BeaconBlockHeader, Checkpoint};
 use crate::primitives::{BlsSignature, Bytes32, Epoch, Hash32, Root, Slot, ValidatorIndex};
 use crate::state_transition::{ForkSchedule, Forks};
@@ -12,6 +13,8 @@ pub enum Error {
     Merkleization(#[from] MerkleizationError),
     #[error("{0}")]
     SimpleSerialize(#[from] SimpleSerializeError),
+    #[error("{0}")]
+    Crypto(#[from] CryptoError),
     #[error("requested element {requested} but collection only has {bound} elements")]
     OutOfBounds { requested: usize, bound: usize },
     #[error("invalid signature")]

--- a/src/state_transition/error.rs
+++ b/src/state_transition/error.rs
@@ -1,5 +1,7 @@
 use crate::phase0::{AttestationData, BeaconBlockHeader, Checkpoint};
-use crate::primitives::{BlsSignature, Bytes32, Epoch, Hash32, Root, Slot, ValidatorIndex};
+use crate::primitives::{
+    BlsPublicKey, BlsSignature, Bytes32, Epoch, Hash32, Root, Slot, ValidatorIndex,
+};
 use crate::state_transition::{ForkSchedule, Forks};
 use ssz_rs::prelude::*;
 use thiserror::Error;
@@ -16,6 +18,8 @@ pub enum Error {
     OutOfBounds { requested: usize, bound: usize },
     #[error("invalid signature")]
     InvalidSignature,
+    #[error("invalid public key")]
+    InvalidPublicKey,
     #[error("collection cannot be empty")]
     CollectionCannotBeEmpty,
     #[error("given index {index} is greater than the total amount of indices {total}")]
@@ -86,6 +90,8 @@ pub enum InvalidOperation {
     VoluntaryExit(#[from] InvalidVoluntaryExit),
     #[error("invalid sync aggregate: {0}")]
     SyncAggregate(#[from] InvalidSyncAggregate),
+    #[error("invalid sync committee: {0}")]
+    SyncCommittee(#[from] InvalidSyncCommittee),
     #[error("invalid execution payload: {0}")]
     ExecutionPayload(#[from] InvalidExecutionPayload),
 }
@@ -211,10 +217,15 @@ pub enum InvalidVoluntaryExit {
 }
 
 #[derive(Debug, Error)]
-#[error("TODO: fill out")]
 pub enum InvalidSyncAggregate {
     #[error("invalid sync committee aggregate signature {signature} signing over previous slot block root {root}")]
     InvalidSignature { signature: BlsSignature, root: Node },
+}
+
+#[derive(Debug, Error)]
+pub enum InvalidSyncCommittee {
+    #[error("invalid aggregated public key for sync committee")]
+    InvalidPublicKey,
 }
 
 #[derive(Debug, Error)]

--- a/src/state_transition/error.rs
+++ b/src/state_transition/error.rs
@@ -1,7 +1,5 @@
 use crate::phase0::{AttestationData, BeaconBlockHeader, Checkpoint};
-use crate::primitives::{
-    BlsPublicKey, BlsSignature, Bytes32, Epoch, Hash32, Root, Slot, ValidatorIndex,
-};
+use crate::primitives::{BlsSignature, Bytes32, Epoch, Hash32, Root, Slot, ValidatorIndex};
 use crate::state_transition::{ForkSchedule, Forks};
 use ssz_rs::prelude::*;
 use thiserror::Error;
@@ -18,8 +16,6 @@ pub enum Error {
     OutOfBounds { requested: usize, bound: usize },
     #[error("invalid signature")]
     InvalidSignature,
-    #[error("invalid public key")]
-    InvalidPublicKey,
     #[error("collection cannot be empty")]
     CollectionCannotBeEmpty,
     #[error("given index {index} is greater than the total amount of indices {total}")]
@@ -90,8 +86,6 @@ pub enum InvalidOperation {
     VoluntaryExit(#[from] InvalidVoluntaryExit),
     #[error("invalid sync aggregate: {0}")]
     SyncAggregate(#[from] InvalidSyncAggregate),
-    #[error("invalid sync committee: {0}")]
-    SyncCommittee(#[from] InvalidSyncCommittee),
     #[error("invalid execution payload: {0}")]
     ExecutionPayload(#[from] InvalidExecutionPayload),
 }
@@ -217,15 +211,10 @@ pub enum InvalidVoluntaryExit {
 }
 
 #[derive(Debug, Error)]
+#[error("TODO: fill out")]
 pub enum InvalidSyncAggregate {
     #[error("invalid sync committee aggregate signature {signature} signing over previous slot block root {root}")]
     InvalidSignature { signature: BlsSignature, root: Node },
-}
-
-#[derive(Debug, Error)]
-pub enum InvalidSyncCommittee {
-    #[error("invalid aggregated public key for sync committee")]
-    InvalidPublicKey,
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
This is a draft PR for https://github.com/ralexstokes/ethereum-consensus/issues/21 -- to implement the Altair spec. Overall, all of the fns have at least been implemented, except the fn mentioned below.

Namely, I'm having an issue with the `block_processing` fn `process_attestation` where I'm borrowing state as mutable (`epoch_participation`), and shortly thereafter, attempting to borrow it as immutable (`proposer_reward_numerator`) within a loop where both are required.

Aside from that, there are misc. instances where I've called out areas I was unsure about as well as a few `clone()`s to make things work. Search for comment leading with `@dev` for these callouts.