### PR TITLE
put libp2p-core behind a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ async = ["tokio", "tokio-stream", "async-stream"]
 spec-tests = ["serde", "serde_json", "serde_yaml"]
 gen-spec = ["syn", "prettyplease", "quote"]
 gen-tests = ["walkdir", "convert_case"]
+peer-id = ["libp2p-core"]
 
 [dependencies]
 ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs" }
@@ -22,7 +23,8 @@ sha2 = "0.9.8"
 integer-sqrt = "0.1.5"
 enr = "0.5.1"
 multiaddr = "0.14.0"
-libp2p-core = { version = "0.32.1", features = ["serde"] }
+
+libp2p-core = { version = "0.32.1", features = ["serde"], optional = true }
 
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0.81", optional = true }

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -13,6 +13,7 @@ pub const RESP_TIMEOUT: Duration = Duration::from_secs(10);
 pub const ATTESTATION_PROPAGATION_SLOT_RANGE: usize = 32;
 pub const MAXIMUM_GOSSIP_CLOCK_DISPARITY: Duration = Duration::from_millis(500);
 
+#[cfg(feature = "peer-id")]
 pub use libp2p_core::PeerId;
 pub use multiaddr::Multiaddr;
 


### PR DESCRIPTION
In Lighthouse we're adding `mev-rs` as a dependency, and bringing in `ethereum-consensus` is currently adding a duplicate version of `libp2p-core` that's different from upstream.

It seems that `mev-rs` doesn't need `PeerId`, so I've turned this feature _off_ by default. If you'd like a feature name other than `peer-id` let me know (maybe `libp2p`?).