### PR TITLE
upgrade enr, libp2p-core dependecies. Feature gate networking

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install
       run: rustup update stable
+    - name: Install protobuf compiler for the libp2p-core dependency
+      uses: arduino/setup-protoc@v1
     - name: Rust Cache
       uses: Swatinem/rust-cache@v1.3.0
     - name: Format

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ rand = "0.8.4"
 thiserror = "1.0.30"
 sha2 = "0.9.8"
 integer-sqrt = "0.1.5"
-enr = {version = "0.5.1", optional = true}
+enr = {version = "0.6.2", optional = true}
 multiaddr = "0.14.0"
 
-libp2p-core = { version = "0.32.1", features = ["serde"], optional = true }
+libp2p-core = { version = "0.36.0", features = ["serde"], optional = true }
 
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0.81", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ spec-tests = ["serde", "serde_yaml"]
 gen-spec = ["syn", "prettyplease", "quote"]
 gen-tests = ["walkdir", "convert_case"]
 peer-id = ["libp2p-core"]
-networking = ["enr"]
+networking = ["enr", "multiaddr"]
 
 [dependencies]
 ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "cb08f1" }
@@ -23,7 +23,7 @@ thiserror = "1.0.30"
 sha2 = "0.9.8"
 integer-sqrt = "0.1.5"
 enr = {version = "0.6.2", optional = true}
-multiaddr = "0.14.0"
+multiaddr = { version = "0.14.0", optional = true }
 
 libp2p-core = { version = "0.36.0", features = ["serde"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,14 @@ license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = ["serde", "async"]
+default = ["serde", "async", "networking"]
 serde = ["dep:serde", "hex", "serde_json"]
 async = ["tokio", "tokio-stream", "async-stream"]
 spec-tests = ["serde", "serde_yaml"]
 gen-spec = ["syn", "prettyplease", "quote"]
 gen-tests = ["walkdir", "convert_case"]
 peer-id = ["libp2p-core"]
+networking = ["enr"]
 
 [dependencies]
 ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "cb08f1" }
@@ -21,7 +22,7 @@ rand = "0.8.4"
 thiserror = "1.0.30"
 sha2 = "0.9.8"
 integer-sqrt = "0.1.5"
-enr = "0.5.1"
+enr = {version = "0.5.1", optional = true}
 multiaddr = "0.14.0"
 
 libp2p-core = { version = "0.32.1", features = ["serde"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod clock;
 pub mod configs;
 pub mod crypto;
 pub mod domains;
+#[cfg(feature = "networking")]
 pub mod networking;
 pub mod phase0;
 pub mod primitives;


### PR DESCRIPTION
Updates the enr and libp2p-core dependecies.
Adds a features `"networking"`, enabled by default for compatibility that gates the networking module. This allows users who don't need it to prevent bringin in the enr and libp2p-core dependencies at all