### PR TITLE
+ `serde::as_string` to `Coordinate.slot`

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -31,6 +31,7 @@ pub type ParticipationFlags = u8;
 // Coordinate refers to a unique location in the block tree
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Coordinate {
+    #[serde(with = "crate::serde::as_string")]
     slot: Slot,
     root: Root,
 }


### PR DESCRIPTION
adds `serde::as_string` to the slot field in the Coordinate struct to enable deserializing from json.