### PR TITLE
clean up ssz byte type formatting

### DIFF
--- a/src/ssz/byte_list.rs
+++ b/src/ssz/byte_list.rs
@@ -37,7 +37,7 @@ impl<const N: usize> fmt::LowerHex for ByteList<N> {
 
 impl<const N: usize> fmt::Debug for ByteList<N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ByteList<{}>(0x{:x})", N, self)
+        write!(f, "ByteList<{}>(len={})({:#x})", N, self.len(), self)
     }
 }
 

--- a/src/ssz/byte_vector.rs
+++ b/src/ssz/byte_vector.rs
@@ -39,7 +39,7 @@ impl<const N: usize> fmt::LowerHex for ByteVector<N> {
 
 impl<const N: usize> fmt::Debug for ByteVector<N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ByteVector<{}>(0x{:x})", N, self)
+        write!(f, "ByteVector<{}>({:#x})", N, self)
     }
 }
 


### PR DESCRIPTION
doing some review of usage of bytes types and code org across this repo and `ssz-rs` and found a few minor cleanups