### PR TITLE
some updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ gen-spec = ["syn", "prettyplease", "quote"]
 gen-tests = ["walkdir", "convert_case"]
 
 [dependencies]
-ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "5946af4a65a1e8547a8fc7cfb62e12637421b8f2" }
+ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "adf1a0b14cef90b9536f28ef89da1fab316465e1" }
 blst = "0.3.6"
 rand = "0.8.4"
 thiserror = "1.0.30"

--- a/src/altair/block_processing.rs
+++ b/src/altair/block_processing.rs
@@ -180,7 +180,7 @@ pub fn process_deposit<
     let branch = deposit
         .proof
         .iter()
-        .map(|node| Node::from_bytes(node.as_ref().try_into().unwrap()))
+        .map(|node| Node::try_from(node.as_ref()).expect("is valid instance"))
         .collect::<Vec<_>>();
     let leaf = deposit.data.hash_tree_root()?;
     let depth = DEPOSIT_CONTRACT_TREE_DEPTH + 1;
@@ -213,7 +213,7 @@ pub fn process_deposit<
         let domain = compute_domain(DomainType::Deposit, None, None, context)?;
         let signing_root = compute_signing_root(&mut deposit_message, domain)?;
 
-        if verify_signature(public_key, signing_root.as_bytes(), &deposit.data.signature).is_err() {
+        if verify_signature(public_key, signing_root.as_ref(), &deposit.data.signature).is_err() {
             // NOTE: explicitly return with no error and also no further mutations to `state`
             return Ok(());
         }

--- a/src/altair/state_transition/block_processing.rs
+++ b/src/altair/state_transition/block_processing.rs
@@ -357,13 +357,7 @@ pub fn process_proposer_slashing<
     ] {
         let signing_root = compute_signing_root(&mut signed_header.message, domain)?;
         let public_key = &proposer.public_key;
-        if verify_signature(
-            public_key,
-            signing_root.as_bytes(),
-            &signed_header.signature,
-        )
-        .is_err()
-        {
+        if verify_signature(public_key, signing_root.as_ref(), &signed_header.signature).is_err() {
             return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
                 InvalidProposerSlashing::InvalidSignature(signed_header.signature.clone()),
             )));
@@ -414,7 +408,7 @@ pub fn process_randao<
     let signing_root = compute_signing_root(&mut epoch, domain)?;
     if verify_signature(
         &proposer.public_key,
-        signing_root.as_bytes(),
+        signing_root.as_ref(),
         &body.randao_reveal,
     )
     .is_err()
@@ -505,7 +499,7 @@ pub fn process_voluntary_exit<
     let public_key = &validator.public_key;
     if verify_signature(
         public_key,
-        signing_root.as_bytes(),
+        signing_root.as_ref(),
         &signed_voluntary_exit.signature,
     )
     .is_err()

--- a/src/altair/state_transition/helpers.rs
+++ b/src/altair/state_transition/helpers.rs
@@ -920,7 +920,7 @@ pub fn is_valid_indexed_attestation<
     let signing_root = compute_signing_root(&mut indexed_attestation.data, domain)?;
     fast_aggregate_verify(
         &public_keys,
-        signing_root.as_bytes(),
+        signing_root.as_ref(),
         &indexed_attestation.signature,
     )
     .map_err(Into::into)
@@ -972,6 +972,5 @@ pub fn verify_block_signature<
     let domain = get_domain(state, DomainType::BeaconProposer, None, context)?;
     let signing_root = compute_signing_root(&mut signed_block.message, domain)?;
     let public_key = &proposer.public_key;
-    verify_signature(public_key, signing_root.as_bytes(), &signed_block.signature)
-        .map_err(Into::into)
+    verify_signature(public_key, signing_root.as_ref(), &signed_block.signature).map_err(Into::into)
 }

--- a/src/bellatrix/state_transition/block_processing.rs
+++ b/src/bellatrix/state_transition/block_processing.rs
@@ -369,7 +369,7 @@ pub fn process_deposit<
     let branch = deposit
         .proof
         .iter()
-        .map(|node| Node::from_bytes(node.as_ref().try_into().unwrap()))
+        .map(|node| Node::try_from(node.as_ref()).expect("is valid instance"))
         .collect::<Vec<_>>();
     let leaf = deposit.data.hash_tree_root()?;
     let depth = DEPOSIT_CONTRACT_TREE_DEPTH + 1;
@@ -399,7 +399,7 @@ pub fn process_deposit<
         };
         let domain = compute_domain(DomainType::Deposit, None, None, context)?;
         let signing_root = compute_signing_root(&mut deposit_message, domain)?;
-        if verify_signature(public_key, signing_root.as_bytes(), &deposit.data.signature).is_err() {
+        if verify_signature(public_key, signing_root.as_ref(), &deposit.data.signature).is_err() {
             return Ok(());
         }
         state
@@ -628,13 +628,7 @@ pub fn process_proposer_slashing<
     ] {
         let signing_root = compute_signing_root(&mut signed_header.message, domain)?;
         let public_key = &proposer.public_key;
-        if verify_signature(
-            public_key,
-            signing_root.as_bytes(),
-            &signed_header.signature,
-        )
-        .is_err()
-        {
+        if verify_signature(public_key, signing_root.as_ref(), &signed_header.signature).is_err() {
             return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
                 InvalidProposerSlashing::InvalidSignature(signed_header.signature.clone()),
             )));
@@ -697,7 +691,7 @@ pub fn process_randao<
     let signing_root = compute_signing_root(&mut epoch, domain)?;
     if verify_signature(
         &proposer.public_key,
-        signing_root.as_bytes(),
+        signing_root.as_ref(),
         &body.randao_reveal,
     )
     .is_err()
@@ -905,7 +899,7 @@ pub fn process_voluntary_exit<
     let public_key = &validator.public_key;
     if verify_signature(
         public_key,
-        signing_root.as_bytes(),
+        signing_root.as_ref(),
         &signed_voluntary_exit.signature,
     )
     .is_err()

--- a/src/bellatrix/state_transition/helpers.rs
+++ b/src/bellatrix/state_transition/helpers.rs
@@ -1423,7 +1423,7 @@ pub fn is_valid_indexed_attestation<
     let signing_root = compute_signing_root(&mut indexed_attestation.data, domain)?;
     fast_aggregate_verify(
         &public_keys,
-        signing_root.as_bytes(),
+        signing_root.as_ref(),
         &indexed_attestation.signature,
     )
     .map_err(Into::into)
@@ -1487,6 +1487,5 @@ pub fn verify_block_signature<
     let domain = get_domain(state, DomainType::BeaconProposer, None, context)?;
     let signing_root = compute_signing_root(&mut signed_block.message, domain)?;
     let public_key = &proposer.public_key;
-    verify_signature(public_key, signing_root.as_bytes(), &signed_block.signature)
-        .map_err(Into::into)
+    verify_signature(public_key, signing_root.as_ref(), &signed_block.signature).map_err(Into::into)
 }

--- a/src/phase0/block_processing.rs
+++ b/src/phase0/block_processing.rs
@@ -90,13 +90,7 @@ pub fn process_proposer_slashing<
     ] {
         let signing_root = compute_signing_root(&mut signed_header.message, domain)?;
         let public_key = &proposer.public_key;
-        if verify_signature(
-            public_key,
-            signing_root.as_bytes(),
-            &signed_header.signature,
-        )
-        .is_err()
-        {
+        if verify_signature(public_key, signing_root.as_ref(), &signed_header.signature).is_err() {
             return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
                 InvalidProposerSlashing::InvalidSignature(signed_header.signature.clone()),
             )));
@@ -342,7 +336,7 @@ pub fn process_deposit<
     let branch = deposit
         .proof
         .iter()
-        .map(|node| Node::from_bytes(node.as_ref().try_into().unwrap()))
+        .map(|node| Node::try_from(node.as_ref()).expect("is valid instance"))
         .collect::<Vec<_>>();
     let leaf = deposit.data.hash_tree_root()?;
     let depth = DEPOSIT_CONTRACT_TREE_DEPTH + 1;
@@ -375,7 +369,7 @@ pub fn process_deposit<
         let domain = compute_domain(DomainType::Deposit, None, None, context)?;
         let signing_root = compute_signing_root(&mut deposit_message, domain)?;
 
-        if verify_signature(public_key, signing_root.as_bytes(), &deposit.data.signature).is_err() {
+        if verify_signature(public_key, signing_root.as_ref(), &deposit.data.signature).is_err() {
             // NOTE: explicitly return with no error and also no further mutations to `state`
             return Ok(());
         }
@@ -477,7 +471,7 @@ pub fn process_voluntary_exit<
     let public_key = &validator.public_key;
     if verify_signature(
         public_key,
-        signing_root.as_bytes(),
+        signing_root.as_ref(),
         &signed_voluntary_exit.signature,
     )
     .is_err()
@@ -637,7 +631,7 @@ pub fn process_randao<
 
     if verify_signature(
         &proposer.public_key,
-        signing_root.as_bytes(),
+        signing_root.as_ref(),
         &body.randao_reveal,
     )
     .is_err()

--- a/src/phase0/helpers.rs
+++ b/src/phase0/helpers.rs
@@ -153,7 +153,7 @@ pub fn is_valid_indexed_attestation<
     let signing_root = compute_signing_root(&mut indexed_attestation.data, domain)?;
     fast_aggregate_verify(
         &public_keys,
-        signing_root.as_bytes(),
+        signing_root.as_ref(),
         &indexed_attestation.signature,
     )
     .map_err(Into::into)
@@ -206,8 +206,7 @@ pub fn verify_block_signature<
     let signing_root = compute_signing_root(&mut signed_block.message, domain)?;
 
     let public_key = &proposer.public_key;
-    verify_signature(public_key, signing_root.as_bytes(), &signed_block.signature)
-        .map_err(Into::into)
+    verify_signature(public_key, signing_root.as_ref(), &signed_block.signature).map_err(Into::into)
 }
 
 pub fn get_domain<

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -23,7 +23,7 @@ pub mod as_hex {
     use super::*;
     use serde::de::Deserialize;
 
-    pub fn serialize<S, T: AsRef<[u8]>>(data: &T, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S, T: AsRef<[u8]>>(data: T, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -52,7 +52,7 @@ pub mod as_string {
     use std::fmt;
     use std::str::FromStr;
 
-    pub fn serialize<S, T: fmt::Display>(data: &T, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S, T: fmt::Display>(data: T, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -38,5 +38,5 @@ pub fn verify_signed_data<T: SimpleSerialize>(
     domain: Domain,
 ) -> Result<(), Error> {
     let signing_root = compute_signing_root(data, domain)?;
-    verify_signature(public_key, signing_root.as_bytes(), signature).map_err(Into::into)
+    verify_signature(public_key, signing_root.as_ref(), signature).map_err(Into::into)
 }


### PR DESCRIPTION
drop unnecessary refs in type sig

update to latest `ssz-rs`