### PR TITLE
fix: sort/duplicate err for is_valid_indexed_attestation

### DIFF
--- a/src/phase0/helpers.rs
+++ b/src/phase0/helpers.rs
@@ -97,22 +97,22 @@ pub fn is_valid_indexed_attestation<
         ));
     }
 
-    // List of indices is non-empty given check above. Begin iteration from one because a list with
-    // a single entry is "sorted" and contains no duplicates.
+    // List of indices is non-empty given check above. Begin iteration from the second element
+    // because a list with a single entry is "sorted" and contains no duplicates.
     let mut prev = attesting_indices[0];
     let mut duplicates = HashSet::new();
-    for index in attesting_indices.as_slice()[1..].iter() {
-        if *index < prev {
+    for &index in &attesting_indices[1..] {
+        if index < prev {
             return Err(invalid_operation_error(
                 InvalidOperation::IndexedAttestation(
                     InvalidIndexedAttestation::AttestingIndicesNotSorted,
                 ),
             ));
         }
-        if *index == prev {
-            duplicates.insert(*index);
+        if index == prev {
+            duplicates.insert(index);
         }
-        prev = *index;
+        prev = index;
     }
     if !duplicates.is_empty() {
         return Err(invalid_operation_error(
@@ -123,14 +123,14 @@ pub fn is_valid_indexed_attestation<
     }
 
     let mut public_keys = vec![];
-    for index in attesting_indices.iter() {
+    for &index in &attesting_indices[..] {
         let public_key = state
             .validators
-            .get(*index)
+            .get(index)
             .map(|v| &v.public_key)
             .ok_or_else(|| {
                 invalid_operation_error(InvalidOperation::IndexedAttestation(
-                    InvalidIndexedAttestation::InvalidIndex(*index),
+                    InvalidIndexedAttestation::InvalidIndex(index),
                 ))
             })?;
         public_keys.push(public_key);

--- a/src/phase0/helpers.rs
+++ b/src/phase0/helpers.rs
@@ -97,48 +97,40 @@ pub fn is_valid_indexed_attestation<
         ));
     }
 
-    let is_sorted = attesting_indices
-        .windows(2)
-        .map(|pair| {
-            let a = &pair[0];
-            let b = &pair[1];
-            a < b
-        })
-        .all(|x| x);
-    if !is_sorted {
-        return Err(invalid_operation_error(
-            InvalidOperation::IndexedAttestation(
-                InvalidIndexedAttestation::AttestingIndicesNotSorted,
-            ),
-        ));
-    }
-
-    let indices: HashSet<usize> = HashSet::from_iter(attesting_indices.iter().cloned());
-    if indices.len() != indexed_attestation.attesting_indices.len() {
-        let mut seen = HashSet::new();
-        let mut duplicates = vec![];
-        for i in indices.iter() {
-            if seen.contains(i) {
-                duplicates.push(*i);
-            } else {
-                seen.insert(i);
-            }
+    // List of indices is non-empty given check above. Begin iteration from one because a list with
+    // a single entry is "sorted" and contains no duplicates.
+    let mut prev = attesting_indices[0];
+    let mut duplicates = HashSet::new();
+    for index in attesting_indices.as_slice()[1..].iter() {
+        if *index < prev {
+            return Err(invalid_operation_error(
+                InvalidOperation::IndexedAttestation(
+                    InvalidIndexedAttestation::AttestingIndicesNotSorted,
+                ),
+            ));
         }
+        if *index == prev {
+            duplicates.insert(*index);
+        }
+        prev = *index;
+    }
+    if !duplicates.is_empty() {
         return Err(invalid_operation_error(
             InvalidOperation::IndexedAttestation(InvalidIndexedAttestation::DuplicateIndices(
-                duplicates,
+                Vec::from_iter(duplicates.into_iter()),
             )),
         ));
     }
+
     let mut public_keys = vec![];
-    for index in indices {
+    for index in attesting_indices.iter() {
         let public_key = state
             .validators
-            .get(index)
+            .get(*index)
             .map(|v| &v.public_key)
             .ok_or_else(|| {
                 invalid_operation_error(InvalidOperation::IndexedAttestation(
-                    InvalidIndexedAttestation::InvalidIndex(index),
+                    InvalidIndexedAttestation::InvalidIndex(*index),
                 ))
             })?;
         public_keys.push(public_key);


### PR DESCRIPTION
the sorted check also accounts for duplicates because the comparator is a strict inequality.

changes:

* check for both sorted and non-duplicate properties in a single pass
* if the list is unsorted, then short-circuit and return `AttestingIndicesNotSorted`
* if the list is (weakly) sorted but contains a duplicate, then return `DuplicateIndices` with a single element for each duplicated index

examples and expected behavior:

1. `[0, 1, 2]`: `Ok(())`
2. `[0, 2, 1]`: `Err(AttestingIndicesNotSorted)`
3. `[0, 1, 1]`: `Err(DuplicateIndices([1]))`
4. `[0, 1, 0]`: `Err(AttestingIndicesNotSorted)`

note: you could also interpret (4) as `DuplicateIndices`. I'm not sure what the correct interpretation is, but I went with `AttestingIndicesNotSorted` because it makes it so that duplicates only occur as neighboring elements.