### PR TITLE
Fix building with no 'serde' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ gen-tests = ["walkdir", "convert_case"]
 ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "adf1a0b14cef90b9536f28ef89da1fab316465e1" }
 blst = "0.3.6"
 rand = "0.8.4"
-thiserror = "= 1.0.30"
+thiserror = "1.0.30"
 sha2 = "0.9.8"
 integer-sqrt = "0.1.5"
 enr = "0.6.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ gen-tests = ["walkdir", "convert_case"]
 ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "adf1a0b14cef90b9536f28ef89da1fab316465e1" }
 blst = "0.3.6"
 rand = "0.8.4"
-thiserror = "1.0.30"
+thiserror = "= 1.0.30"
 sha2 = "0.9.8"
 integer-sqrt = "0.1.5"
 enr = "0.6.2"

--- a/src/altair/beacon_block.rs
+++ b/src/altair/beacon_block.rs
@@ -39,9 +39,9 @@ pub struct BeaconBlock<
     const MAX_VOLUNTARY_EXITS: usize,
     const SYNC_COMMITTEE_SIZE: usize,
 > {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub slot: Slot,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub proposer_index: ValidatorIndex,
     pub parent_root: Root,
     pub state_root: Root,

--- a/src/altair/beacon_state.rs
+++ b/src/altair/beacon_state.rs
@@ -17,10 +17,10 @@ pub struct BeaconState<
     const MAX_VALIDATORS_PER_COMMITTEE: usize,
     const SYNC_COMMITTEE_SIZE: usize,
 > {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub genesis_time: u64,
     pub genesis_validators_root: Root,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub slot: Slot,
     pub fork: Fork,
     pub latest_block_header: BeaconBlockHeader,
@@ -29,23 +29,23 @@ pub struct BeaconState<
     pub historical_roots: List<Root, HISTORICAL_ROOTS_LIMIT>,
     pub eth1_data: Eth1Data,
     pub eth1_data_votes: List<Eth1Data, ETH1_DATA_VOTES_BOUND>,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub eth1_deposit_index: u64,
     pub validators: List<Validator, VALIDATOR_REGISTRY_LIMIT>,
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub balances: List<Gwei, VALIDATOR_REGISTRY_LIMIT>,
     pub randao_mixes: Vector<Bytes32, EPOCHS_PER_HISTORICAL_VECTOR>,
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub slashings: Vector<Gwei, EPOCHS_PER_SLASHINGS_VECTOR>,
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub previous_epoch_participation: List<ParticipationFlags, VALIDATOR_REGISTRY_LIMIT>,
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub current_epoch_participation: List<ParticipationFlags, VALIDATOR_REGISTRY_LIMIT>,
     pub justification_bits: Bitvector<JUSTIFICATION_BITS_LENGTH>,
     pub previous_justified_checkpoint: Checkpoint,
     pub current_justified_checkpoint: Checkpoint,
     pub finalized_checkpoint: Checkpoint,
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub inactivity_scores: List<u64, VALIDATOR_REGISTRY_LIMIT>,
     pub current_sync_committee: SyncCommittee<SYNC_COMMITTEE_SIZE>,
     pub next_sync_committee: SyncCommittee<SYNC_COMMITTEE_SIZE>,

--- a/src/altair/beacon_state.rs
+++ b/src/altair/beacon_state.rs
@@ -32,20 +32,35 @@ pub struct BeaconState<
     #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub eth1_deposit_index: u64,
     pub validators: List<Validator, VALIDATOR_REGISTRY_LIMIT>,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub balances: List<Gwei, VALIDATOR_REGISTRY_LIMIT>,
     pub randao_mixes: Vector<Bytes32, EPOCHS_PER_HISTORICAL_VECTOR>,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub slashings: Vector<Gwei, EPOCHS_PER_SLASHINGS_VECTOR>,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub previous_epoch_participation: List<ParticipationFlags, VALIDATOR_REGISTRY_LIMIT>,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub current_epoch_participation: List<ParticipationFlags, VALIDATOR_REGISTRY_LIMIT>,
     pub justification_bits: Bitvector<JUSTIFICATION_BITS_LENGTH>,
     pub previous_justified_checkpoint: Checkpoint,
     pub current_justified_checkpoint: Checkpoint,
     pub finalized_checkpoint: Checkpoint,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub inactivity_scores: List<u64, VALIDATOR_REGISTRY_LIMIT>,
     pub current_sync_committee: SyncCommittee<SYNC_COMMITTEE_SIZE>,
     pub next_sync_committee: SyncCommittee<SYNC_COMMITTEE_SIZE>,

--- a/src/altair/sync.rs
+++ b/src/altair/sync.rs
@@ -11,8 +11,8 @@ pub struct SyncAggregate<const SYNC_COMMITTEE_SIZE: usize> {
 #[derive(Default, Debug, SimpleSerialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SyncCommittee<const SYNC_COMMITTEE_SIZE: usize> {
-    #[serde(rename = "pubkeys")]
+    #[cfg_attr(feature = "serde", serde(rename = "pubkeys"))]
     pub public_keys: Vector<BlsPublicKey, SYNC_COMMITTEE_SIZE>,
-    #[serde(rename = "aggregate_pubkey")]
+    #[cfg_attr(feature = "serde", serde(rename = "aggregate_pubkey"))]
     pub aggregate_public_key: BlsPublicKey,
 }

--- a/src/altair/validator.rs
+++ b/src/altair/validator.rs
@@ -6,10 +6,10 @@ pub const SYNC_COMMITTEE_SUBNET_COUNT: usize = 4;
 #[derive(Debug, Default, Clone, SimpleSerialize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SyncCommitteeMessage {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub slot: Slot,
     pub beacon_block_root: Root,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub validator_index: ValidatorIndex,
     pub signature: BlsSignature,
 }
@@ -21,10 +21,10 @@ pub(super) const fn get_sync_subcommittee_size(sync_committee_size: usize) -> us
 #[derive(Debug, Default, Clone, SimpleSerialize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SyncCommitteeContribution<const SYNC_SUBCOMMITTEE_SIZE: usize> {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub slot: Slot,
     pub beacon_block_root: Root,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub subcommittee_index: u64,
     pub aggregation_bits: Bitvector<SYNC_SUBCOMMITTEE_SIZE>,
     pub signature: BlsSignature,
@@ -33,7 +33,7 @@ pub struct SyncCommitteeContribution<const SYNC_SUBCOMMITTEE_SIZE: usize> {
 #[derive(Debug, Default, Clone, SimpleSerialize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ContributionAndProof<const SYNC_SUBCOMMITTEE_SIZE: usize> {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub aggregator_index: ValidatorIndex,
     pub contribution: SyncCommitteeContribution<SYNC_SUBCOMMITTEE_SIZE>,
     pub selection_proof: BlsSignature,

--- a/src/bellatrix/beacon_block.rs
+++ b/src/bellatrix/beacon_block.rs
@@ -54,9 +54,9 @@ pub struct BeaconBlock<
     const MAX_BYTES_PER_TRANSACTION: usize,
     const MAX_TRANSACTIONS_PER_PAYLOAD: usize,
 > {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub slot: Slot,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub proposer_index: ValidatorIndex,
     pub parent_root: Root,
     pub state_root: Root,

--- a/src/bellatrix/beacon_state.rs
+++ b/src/bellatrix/beacon_state.rs
@@ -22,10 +22,10 @@ pub struct BeaconState<
     const MAX_BYTES_PER_TRANSACTION: usize,
     const MAX_TRANSACTIONS_PER_PAYLOAD: usize,
 > {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub genesis_time: u64,
     pub genesis_validators_root: Root,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub slot: Slot,
     pub fork: Fork,
     pub latest_block_header: BeaconBlockHeader,
@@ -34,23 +34,23 @@ pub struct BeaconState<
     pub historical_roots: List<Root, HISTORICAL_ROOTS_LIMIT>,
     pub eth1_data: Eth1Data,
     pub eth1_data_votes: List<Eth1Data, ETH1_DATA_VOTES_BOUND>,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub eth1_deposit_index: u64,
     pub validators: List<Validator, VALIDATOR_REGISTRY_LIMIT>,
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub balances: List<Gwei, VALIDATOR_REGISTRY_LIMIT>,
     pub randao_mixes: Vector<Bytes32, EPOCHS_PER_HISTORICAL_VECTOR>,
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub slashings: Vector<Gwei, EPOCHS_PER_SLASHINGS_VECTOR>,
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub previous_epoch_participation: List<ParticipationFlags, VALIDATOR_REGISTRY_LIMIT>,
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub current_epoch_participation: List<ParticipationFlags, VALIDATOR_REGISTRY_LIMIT>,
     pub justification_bits: Bitvector<JUSTIFICATION_BITS_LENGTH>,
     pub previous_justified_checkpoint: Checkpoint,
     pub current_justified_checkpoint: Checkpoint,
     pub finalized_checkpoint: Checkpoint,
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub inactivity_scores: List<u64, VALIDATOR_REGISTRY_LIMIT>,
     pub current_sync_committee: SyncCommittee<SYNC_COMMITTEE_SIZE>,
     pub next_sync_committee: SyncCommittee<SYNC_COMMITTEE_SIZE>,

--- a/src/bellatrix/beacon_state.rs
+++ b/src/bellatrix/beacon_state.rs
@@ -37,20 +37,35 @@ pub struct BeaconState<
     #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub eth1_deposit_index: u64,
     pub validators: List<Validator, VALIDATOR_REGISTRY_LIMIT>,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub balances: List<Gwei, VALIDATOR_REGISTRY_LIMIT>,
     pub randao_mixes: Vector<Bytes32, EPOCHS_PER_HISTORICAL_VECTOR>,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub slashings: Vector<Gwei, EPOCHS_PER_SLASHINGS_VECTOR>,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub previous_epoch_participation: List<ParticipationFlags, VALIDATOR_REGISTRY_LIMIT>,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub current_epoch_participation: List<ParticipationFlags, VALIDATOR_REGISTRY_LIMIT>,
     pub justification_bits: Bitvector<JUSTIFICATION_BITS_LENGTH>,
     pub previous_justified_checkpoint: Checkpoint,
     pub current_justified_checkpoint: Checkpoint,
     pub finalized_checkpoint: Checkpoint,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub inactivity_scores: List<u64, VALIDATOR_REGISTRY_LIMIT>,
     pub current_sync_committee: SyncCommittee<SYNC_COMMITTEE_SIZE>,
     pub next_sync_committee: SyncCommittee<SYNC_COMMITTEE_SIZE>,

--- a/src/bellatrix/blinded_beacon_block.rs
+++ b/src/bellatrix/blinded_beacon_block.rs
@@ -54,9 +54,9 @@ pub struct BlindedBeaconBlock<
     const MAX_BYTES_PER_TRANSACTION: usize,
     const MAX_TRANSACTIONS_PER_PAYLOAD: usize,
 > {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub slot: Slot,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub proposer_index: ValidatorIndex,
     pub parent_root: Root,
     pub state_root: Root,

--- a/src/bellatrix/execution.rs
+++ b/src/bellatrix/execution.rs
@@ -19,13 +19,13 @@ pub struct ExecutionPayload<
     pub receipts_root: Bytes32,
     pub logs_bloom: ByteVector<BYTES_PER_LOGS_BLOOM>,
     pub prev_randao: Bytes32,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub block_number: u64,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub gas_limit: u64,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub gas_used: u64,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub timestamp: u64,
     pub extra_data: ByteList<MAX_EXTRA_DATA_BYTES>,
     pub base_fee_per_gas: U256,
@@ -47,13 +47,13 @@ pub struct ExecutionPayloadHeader<
     pub receipts_root: Bytes32,
     pub logs_bloom: ByteVector<BYTES_PER_LOGS_BLOOM>,
     pub prev_randao: Bytes32,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub block_number: u64,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub gas_limit: u64,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub gas_used: u64,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub timestamp: u64,
     pub extra_data: ByteList<MAX_EXTRA_DATA_BYTES>,
     pub base_fee_per_gas: U256,

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -7,11 +7,11 @@ use ssz_rs::prelude::*;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValidatorRegistration {
     pub fee_recipient: ExecutionAddress,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub gas_limit: u64,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub timestamp: u64,
-    #[serde(rename = "pubkey")]
+    #[cfg_attr(feature = "serde", serde(rename = "pubkey"))]
     pub public_key: BlsPublicKey,
 }
 

--- a/src/capella/beacon_block.rs
+++ b/src/capella/beacon_block.rs
@@ -60,9 +60,9 @@ pub struct BeaconBlock<
     const MAX_WITHDRAWALS_PER_PAYLOAD: usize,
     const MAX_BLS_TO_EXECUTION_CHANGES: usize,
 > {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub slot: Slot,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub proposer_index: ValidatorIndex,
     pub parent_root: Root,
     pub state_root: Root,

--- a/src/capella/beacon_state.rs
+++ b/src/capella/beacon_state.rs
@@ -24,10 +24,10 @@ pub struct BeaconState<
     const MAX_BYTES_PER_TRANSACTION: usize,
     const MAX_TRANSACTIONS_PER_PAYLOAD: usize,
 > {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub genesis_time: u64,
     pub genesis_validators_root: Root,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub slot: Slot,
     pub fork: Fork,
     pub latest_block_header: BeaconBlockHeader,
@@ -36,31 +36,31 @@ pub struct BeaconState<
     pub historical_roots: List<Root, HISTORICAL_ROOTS_LIMIT>,
     pub eth1_data: Eth1Data,
     pub eth1_data_votes: List<Eth1Data, ETH1_DATA_VOTES_BOUND>,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub eth1_deposit_index: u64,
     pub validators: List<Validator, VALIDATOR_REGISTRY_LIMIT>,
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub balances: List<Gwei, VALIDATOR_REGISTRY_LIMIT>,
     pub randao_mixes: Vector<Bytes32, EPOCHS_PER_HISTORICAL_VECTOR>,
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub slashings: Vector<Gwei, EPOCHS_PER_SLASHINGS_VECTOR>,
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub previous_epoch_participation: List<ParticipationFlags, VALIDATOR_REGISTRY_LIMIT>,
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub current_epoch_participation: List<ParticipationFlags, VALIDATOR_REGISTRY_LIMIT>,
     pub justification_bits: Bitvector<JUSTIFICATION_BITS_LENGTH>,
     pub previous_justified_checkpoint: Checkpoint,
     pub current_justified_checkpoint: Checkpoint,
     pub finalized_checkpoint: Checkpoint,
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub inactivity_scores: List<u64, VALIDATOR_REGISTRY_LIMIT>,
     pub current_sync_committee: SyncCommittee<SYNC_COMMITTEE_SIZE>,
     pub next_sync_committee: SyncCommittee<SYNC_COMMITTEE_SIZE>,
     pub latest_execution_payload_header:
         ExecutionPayloadHeader<BYTES_PER_LOGS_BLOOM, MAX_EXTRA_DATA_BYTES>,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub next_withdrawal_index: WithdrawalIndex,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub next_withdrawal_validator_index: ValidatorIndex,
     pub historical_summaries: List<HistoricalSummary, HISTORICAL_ROOTS_LIMIT>,
 }

--- a/src/capella/beacon_state.rs
+++ b/src/capella/beacon_state.rs
@@ -39,20 +39,35 @@ pub struct BeaconState<
     #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub eth1_deposit_index: u64,
     pub validators: List<Validator, VALIDATOR_REGISTRY_LIMIT>,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub balances: List<Gwei, VALIDATOR_REGISTRY_LIMIT>,
     pub randao_mixes: Vector<Bytes32, EPOCHS_PER_HISTORICAL_VECTOR>,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub slashings: Vector<Gwei, EPOCHS_PER_SLASHINGS_VECTOR>,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub previous_epoch_participation: List<ParticipationFlags, VALIDATOR_REGISTRY_LIMIT>,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub current_epoch_participation: List<ParticipationFlags, VALIDATOR_REGISTRY_LIMIT>,
     pub justification_bits: Bitvector<JUSTIFICATION_BITS_LENGTH>,
     pub previous_justified_checkpoint: Checkpoint,
     pub current_justified_checkpoint: Checkpoint,
     pub finalized_checkpoint: Checkpoint,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub inactivity_scores: List<u64, VALIDATOR_REGISTRY_LIMIT>,
     pub current_sync_committee: SyncCommittee<SYNC_COMMITTEE_SIZE>,
     pub next_sync_committee: SyncCommittee<SYNC_COMMITTEE_SIZE>,

--- a/src/capella/blinded_beacon_block.rs
+++ b/src/capella/blinded_beacon_block.rs
@@ -55,9 +55,9 @@ pub struct BlindedBeaconBlock<
     const MAX_WITHDRAWALS_PER_PAYLOAD: usize,
     const MAX_BLS_TO_EXECUTION_CHANGES: usize,
 > {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub slot: Slot,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub proposer_index: ValidatorIndex,
     pub parent_root: Root,
     pub state_root: Root,

--- a/src/capella/bls_to_execution_change.rs
+++ b/src/capella/bls_to_execution_change.rs
@@ -4,9 +4,9 @@ use ssz_rs::prelude::*;
 #[derive(Default, Debug, Clone, SimpleSerialize, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BlsToExecutionChange {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub validator_index: ValidatorIndex,
-    #[serde(rename = "from_bls_pubkey")]
+    #[cfg_attr(feature = "serde", serde(rename = "from_bls_pubkey"))]
     pub from_bls_public_key: BlsPublicKey,
     pub to_execution_address: ExecutionAddress,
 }

--- a/src/capella/execution.rs
+++ b/src/capella/execution.rs
@@ -20,13 +20,13 @@ pub struct ExecutionPayload<
     pub receipts_root: Bytes32,
     pub logs_bloom: ByteVector<BYTES_PER_LOGS_BLOOM>,
     pub prev_randao: Bytes32,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub block_number: u64,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub gas_limit: u64,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub gas_used: u64,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub timestamp: u64,
     pub extra_data: ByteList<MAX_EXTRA_DATA_BYTES>,
     pub base_fee_per_gas: U256,
@@ -47,13 +47,13 @@ pub struct ExecutionPayloadHeader<
     pub receipts_root: Bytes32,
     pub logs_bloom: ByteVector<BYTES_PER_LOGS_BLOOM>,
     pub prev_randao: Bytes32,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub block_number: u64,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub gas_limit: u64,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub gas_used: u64,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub timestamp: u64,
     pub extra_data: ByteList<MAX_EXTRA_DATA_BYTES>,
     pub base_fee_per_gas: U256,

--- a/src/capella/withdrawal.rs
+++ b/src/capella/withdrawal.rs
@@ -4,11 +4,11 @@ use ssz_rs::prelude::*;
 #[derive(Default, Debug, Clone, SimpleSerialize, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Withdrawal {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub index: WithdrawalIndex,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub validator_index: ValidatorIndex,
     pub address: ExecutionAddress,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub amount: Gwei,
 }

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -19,20 +19,20 @@ pub struct Config {
 
     pub min_genesis_active_validator_count: usize,
     pub min_genesis_time: u64,
-    #[serde(with = "crate::serde::as_hex")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_hex"))]
     pub genesis_fork_version: Version,
     pub genesis_delay: u64,
 
-    #[serde(with = "crate::serde::as_hex")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_hex"))]
     pub altair_fork_version: Version,
     pub altair_fork_epoch: Epoch,
-    #[serde(with = "crate::serde::as_hex")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_hex"))]
     pub bellatrix_fork_version: Version,
     pub bellatrix_fork_epoch: Epoch,
-    #[serde(with = "crate::serde::as_hex")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_hex"))]
     pub capella_fork_version: Version,
     pub capella_fork_epoch: Epoch,
-    #[serde(with = "crate::serde::as_hex")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_hex"))]
     pub eip4844_fork_version: Version,
     pub eip4844_fork_epoch: Epoch,
 

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -139,7 +139,7 @@ pub enum MessageDomain {
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MetaData {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub seq_number: u64,
     pub attnets: Bitvector<ATTESTATION_SUBNET_COUNT>,
 }

--- a/src/phase0/beacon_block.rs
+++ b/src/phase0/beacon_block.rs
@@ -35,9 +35,9 @@ pub struct BeaconBlock<
     const MAX_DEPOSITS: usize,
     const MAX_VOLUNTARY_EXITS: usize,
 > {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub slot: Slot,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub proposer_index: ValidatorIndex,
     pub parent_root: Root,
     pub state_root: Root,
@@ -75,9 +75,9 @@ pub struct SignedBeaconBlock<
 #[derive(Default, Debug, SimpleSerialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BeaconBlockHeader {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub slot: Slot,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub proposer_index: ValidatorIndex,
     pub parent_root: Root,
     pub state_root: Root,

--- a/src/phase0/beacon_state.rs
+++ b/src/phase0/beacon_state.rs
@@ -73,10 +73,16 @@ pub struct BeaconState<
     #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub eth1_deposit_index: u64,
     pub validators: List<Validator, VALIDATOR_REGISTRY_LIMIT>,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub balances: List<Gwei, VALIDATOR_REGISTRY_LIMIT>,
     pub randao_mixes: Vector<Bytes32, EPOCHS_PER_HISTORICAL_VECTOR>,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub slashings: Vector<Gwei, EPOCHS_PER_SLASHINGS_VECTOR>,
     pub previous_epoch_attestations:
         List<PendingAttestation<MAX_VALIDATORS_PER_COMMITTEE>, PENDING_ATTESTATIONS_BOUND>,

--- a/src/phase0/beacon_state.rs
+++ b/src/phase0/beacon_state.rs
@@ -58,10 +58,10 @@ pub struct BeaconState<
     const MAX_VALIDATORS_PER_COMMITTEE: usize,
     const PENDING_ATTESTATIONS_BOUND: usize,
 > {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub genesis_time: u64,
     pub genesis_validators_root: Root,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub slot: Slot,
     pub fork: Fork,
     pub latest_block_header: BeaconBlockHeader,
@@ -70,13 +70,13 @@ pub struct BeaconState<
     pub historical_roots: List<Root, HISTORICAL_ROOTS_LIMIT>,
     pub eth1_data: Eth1Data,
     pub eth1_data_votes: List<Eth1Data, ETH1_DATA_VOTES_BOUND>,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub eth1_deposit_index: u64,
     pub validators: List<Validator, VALIDATOR_REGISTRY_LIMIT>,
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub balances: List<Gwei, VALIDATOR_REGISTRY_LIMIT>,
     pub randao_mixes: Vector<Bytes32, EPOCHS_PER_HISTORICAL_VECTOR>,
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub slashings: Vector<Gwei, EPOCHS_PER_SLASHINGS_VECTOR>,
     pub previous_epoch_attestations:
         List<PendingAttestation<MAX_VALIDATORS_PER_COMMITTEE>, PENDING_ATTESTATIONS_BOUND>,

--- a/src/phase0/fork.rs
+++ b/src/phase0/fork.rs
@@ -4,18 +4,18 @@ use ssz_rs::prelude::*;
 #[derive(Default, Debug, SimpleSerialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Fork {
-    #[serde(with = "crate::serde::as_hex")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_hex"))]
     pub previous_version: Version,
-    #[serde(with = "crate::serde::as_hex")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_hex"))]
     pub current_version: Version,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub epoch: Epoch,
 }
 
 #[derive(Default, Debug, SimpleSerialize, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ForkData {
-    #[serde(with = "crate::serde::as_hex")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_hex"))]
     pub current_version: Version,
     pub genesis_validators_root: Root,
 }

--- a/src/phase0/operations.rs
+++ b/src/phase0/operations.rs
@@ -28,7 +28,10 @@ pub struct AttestationData {
 #[derive(Default, Debug, SimpleSerialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IndexedAttestation<const MAX_VALIDATORS_PER_COMMITTEE: usize> {
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde::collection_over_string")
+    )]
     pub attesting_indices: List<ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE>,
     pub data: AttestationData,
     pub signature: BlsSignature,

--- a/src/phase0/operations.rs
+++ b/src/phase0/operations.rs
@@ -8,7 +8,7 @@ use ssz_rs::prelude::*;
 #[derive(Default, Clone, Debug, SimpleSerialize, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Checkpoint {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub epoch: Epoch,
     pub root: Root,
 }
@@ -16,9 +16,9 @@ pub struct Checkpoint {
 #[derive(Default, Clone, Debug, SimpleSerialize, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AttestationData {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub slot: Slot,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub index: CommitteeIndex,
     pub beacon_block_root: Root,
     pub source: Checkpoint,
@@ -28,7 +28,7 @@ pub struct AttestationData {
 #[derive(Default, Debug, SimpleSerialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IndexedAttestation<const MAX_VALIDATORS_PER_COMMITTEE: usize> {
-    #[serde(with = "crate::serde::collection_over_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::collection_over_string"))]
     pub attesting_indices: List<ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE>,
     pub data: AttestationData,
     pub signature: BlsSignature,
@@ -39,9 +39,9 @@ pub struct IndexedAttestation<const MAX_VALIDATORS_PER_COMMITTEE: usize> {
 pub struct PendingAttestation<const MAX_VALIDATORS_PER_COMMITTEE: usize> {
     pub aggregation_bits: Bitlist<MAX_VALIDATORS_PER_COMMITTEE>,
     pub data: AttestationData,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub inclusion_delay: Slot,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub proposer_index: ValidatorIndex,
 }
 
@@ -57,7 +57,7 @@ pub struct Attestation<const MAX_VALIDATORS_PER_COMMITTEE: usize> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Eth1Data {
     pub deposit_root: Root,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub deposit_count: u64,
     pub block_hash: Hash32,
 }
@@ -65,20 +65,20 @@ pub struct Eth1Data {
 #[derive(Default, Debug, SimpleSerialize, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DepositMessage {
-    #[serde(rename = "pubkey")]
+    #[cfg_attr(feature = "serde", serde(rename = "pubkey"))]
     pub public_key: BlsPublicKey,
     pub withdrawal_credentials: Bytes32,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub amount: Gwei,
 }
 
 #[derive(Default, Debug, Clone, SimpleSerialize, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DepositData {
-    #[serde(rename = "pubkey")]
+    #[cfg_attr(feature = "serde", serde(rename = "pubkey"))]
     pub public_key: BlsPublicKey,
     pub withdrawal_credentials: Bytes32,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub amount: Gwei,
     pub signature: BlsSignature,
 }
@@ -113,9 +113,9 @@ pub struct Deposit {
 #[derive(Default, Debug, SimpleSerialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VoluntaryExit {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub epoch: Epoch,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub validator_index: ValidatorIndex,
 }
 

--- a/src/phase0/validator.rs
+++ b/src/phase0/validator.rs
@@ -5,20 +5,20 @@ use ssz_rs::prelude::*;
 #[derive(Default, Debug, SimpleSerialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Validator {
-    #[serde(rename = "pubkey")]
+    #[cfg_attr(feature = "serde", serde(rename = "pubkey"))]
     pub public_key: BlsPublicKey,
     pub withdrawal_credentials: Bytes32,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub effective_balance: Gwei,
     pub slashed: bool,
     // Status epochs
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub activation_eligibility_epoch: Epoch,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub activation_epoch: Epoch,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub exit_epoch: Epoch,
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub withdrawable_epoch: Epoch,
 }
 
@@ -33,7 +33,7 @@ pub struct Eth1Block {
 #[derive(Default, Debug, SimpleSerialize, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AggregateAndProof<const MAX_VALIDATORS_PER_COMMITTEE: usize> {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     pub aggregator_index: ValidatorIndex,
     pub aggregate: Attestation<MAX_VALIDATORS_PER_COMMITTEE>,
     pub selection_proof: BlsSignature,

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -32,7 +32,7 @@ pub type ParticipationFlags = u8;
 // Coordinate refers to a unique location in the block tree
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Coordinate {
-    #[serde(with = "crate::serde::as_string")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_string"))]
     slot: Slot,
     root: Root,
 }

--- a/src/ssz/byte_list.rs
+++ b/src/ssz/byte_list.rs
@@ -6,7 +6,9 @@ use std::ops::{Deref, DerefMut};
 
 #[derive(Default, Clone, Eq, SimpleSerialize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ByteList<const N: usize>(#[cfg_attr(feature = "serde", serde(with = "crate::serde::as_hex"))] List<u8, N>);
+pub struct ByteList<const N: usize>(
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_hex"))] List<u8, N>,
+);
 
 impl<const N: usize> TryFrom<&[u8]> for ByteList<N> {
     type Error = ssz_rs::DeserializeError;

--- a/src/ssz/byte_list.rs
+++ b/src/ssz/byte_list.rs
@@ -6,7 +6,7 @@ use std::ops::{Deref, DerefMut};
 
 #[derive(Default, Clone, Eq, SimpleSerialize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ByteList<const N: usize>(#[serde(with = "crate::serde::as_hex")] List<u8, N>);
+pub struct ByteList<const N: usize>(#[cfg_attr(feature = "serde", serde(with = "crate::serde::as_hex"))] List<u8, N>);
 
 impl<const N: usize> TryFrom<&[u8]> for ByteList<N> {
     type Error = ssz_rs::DeserializeError;

--- a/src/ssz/byte_vector.rs
+++ b/src/ssz/byte_vector.rs
@@ -6,7 +6,7 @@ use std::ops::{Deref, DerefMut};
 
 #[derive(Default, Clone, Eq, SimpleSerialize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ByteVector<const N: usize>(#[serde(with = "crate::serde::as_hex")] Vector<u8, N>);
+pub struct ByteVector<const N: usize>(#[cfg_attr(feature = "serde", serde(with = "crate::serde::as_hex"))] Vector<u8, N>);
 
 impl<const N: usize> TryFrom<&[u8]> for ByteVector<N> {
     type Error = ssz_rs::DeserializeError;

--- a/src/ssz/byte_vector.rs
+++ b/src/ssz/byte_vector.rs
@@ -6,7 +6,9 @@ use std::ops::{Deref, DerefMut};
 
 #[derive(Default, Clone, Eq, SimpleSerialize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ByteVector<const N: usize>(#[cfg_attr(feature = "serde", serde(with = "crate::serde::as_hex"))] Vector<u8, N>);
+pub struct ByteVector<const N: usize>(
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::as_hex"))] Vector<u8, N>,
+);
 
 impl<const N: usize> TryFrom<&[u8]> for ByteVector<N> {
     type Error = ssz_rs::DeserializeError;

--- a/tests/spec_test_runners/bls/mod.rs
+++ b/tests/spec_test_runners/bls/mod.rs
@@ -289,7 +289,7 @@ impl TestCase for EthAggregatePubkeysTestCase {
 #[serde_as]
 #[derive(Debug, Deserialize)]
 struct EthFastAggregateVerifyInput {
-    #[serde(rename = "pubkeys")]
+    #[cfg_attr(feature = "serde", serde(rename = "pubkeys"))]
     public_keys: Vec<String>,
     message: Bytes32,
     #[serde_as(deserialize_as = "DefaultOnError")]


### PR DESCRIPTION
When trying to build the crate without the serde feature enabled e.g.
```
cargo check --no-default-features
```
It was failing because the field attributes were not gated by the feature, only the struct attributes.

---

This PR uses `#[cfg_attr(feature = "serde", ...)]` on the field attributes as well. This allows the project to build with `--no-default-features` again.