### PR TITLE
docs: minor fixes

### DIFF
--- a/src/bin/README.md
+++ b/src/bin/README.md
@@ -4,6 +4,6 @@ Generates Rust source of future forks of the consensus spec based on prior forks
 
 Ping @ralexstokes if you need help here, this works but it is quite bespoke code and could be refined so it is easier to maintain and extend.
 
-# `gen-tests
+# `gen-tests`
 
 Generates `rustc` tests that correspond to each test case in the `consensus-spec-tests`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,7 @@ The consensus spec tests repo is [here](https://github.com/ethereum/consensus-sp
 In order to run tests against the consensus spec test repo, use the following commands:
 
 ```
-just build-integration-tests
+just download-integration-tests
 just run-integration-tests
 ```
 


### PR DESCRIPTION
minor fixes:

* add missing inline code delimiter for `gen-tests`
* change spec test instruction from `build-integration-tests` to `download-integration-tests`