### PR TITLE
add debug to some types

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -31,6 +31,7 @@ pub type ParticipationFlags = u8;
 
 // Coordinate refers to a unique location in the block tree
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug)]
 pub struct Coordinate {
     #[serde(with = "crate::serde::as_string")]
     slot: Slot,


### PR DESCRIPTION
tiny PR to add `Debug` to `Coordinate` type.
Motivated by CLI development [here](https://github.com/ralexstokes/beacon-api-client/pull/61)