### PR TITLE
Fix incorrect field name in `BlindedBlobSidecar`

### DIFF
--- a/ethereum-consensus/src/deneb/blinded_blob_sidecar.rs
+++ b/ethereum-consensus/src/deneb/blinded_blob_sidecar.rs
@@ -10,7 +10,7 @@ pub struct BlindedBlobSidecar<const BYTES_PER_BLOB: usize> {
     pub block_root: Root,
     #[serde(with = "crate::serde::as_string")]
     pub index: BlobIndex,
-    pub block_slot: Slot,
+    pub slot: Slot,
     pub block_parent_root: Root,
     #[serde(with = "crate::serde::as_string")]
     pub proposer_index: ValidatorIndex,


### PR DESCRIPTION
The slot field name should be `slot` instead of `block_slot`. 

Spec for `BlindedBlobSidecar`:
https://github.com/ethereum/builder-specs/blob/534e4f81276b8346d785ed9aba12c4c74b927ec6/specs/deneb/builder.md?plain=1#L44-L53