### PR TITLE
produce output for `lighthouse validator-manager import`

### DIFF
--- a/ethereum-consensus/src/bin/ec/validator/keystores.rs
+++ b/ethereum-consensus/src/bin/ec/validator/keystores.rs
@@ -28,6 +28,14 @@ where
     s.collect_str(&"")
 }
 
+fn as_json_str<S, D: Serialize>(data: D, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let encoding = serde_json::to_string(&data).unwrap();
+    s.collect_str(&encoding)
+}
+
 pub type Passphrase = String;
 const PASSPHRASE_LEN: usize = 32;
 
@@ -201,7 +209,12 @@ impl Keystore {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct KeystoreWithPassphrase {
+    // NOTE: this JSON name is lighthouse specific
+    #[serde(rename = "voting_keystore")]
+    #[serde(serialize_with = "as_json_str")]
     keystore: Keystore,
+    // NOTE: this JSON name is lighthouse specific
+    #[serde(rename = "voting_keystore_password")]
     passphrase: Passphrase,
 }
 

--- a/ethereum-consensus/src/bin/ec/validator/mod.rs
+++ b/ethereum-consensus/src/bin/ec/validator/mod.rs
@@ -7,7 +7,17 @@ use clap::{Args, Subcommand};
 #[derive(Debug, Subcommand)]
 pub enum Commands {
     Mnemonic,
-    GenerateKeystores { phrase: String, start: u32, end: u32 },
+    #[clap(
+        about = "Generates keystores (with passphrases) that target a format compatible with `lighthouse validator-manager` utility."
+    )]
+    GenerateLighthouseKeystores {
+        #[clap(help = "BIP-39 mnemonic to use following EIP-2334")]
+        phrase: String,
+        #[clap(help = "EIP-2334 index to start key generation (inclusive)")]
+        start: u32,
+        #[clap(help = "EIP-2334 index to stop key generation (exclusive)")]
+        end: u32,
+    },
 }
 
 #[derive(Debug, Args)]
@@ -25,7 +35,7 @@ impl Command {
                 println!("{}", mnemonic);
                 Ok(())
             }
-            Commands::GenerateKeystores { phrase, start, end } => {
+            Commands::GenerateLighthouseKeystores { phrase, start, end } => {
                 let mnemonic = mnemonic::recover_from_phrase(&phrase)?;
                 let seed = mnemonic::to_seed(mnemonic, None);
                 let (signing_keys, _withdrawal_keys) = keys::generate(&seed, start, end);


### PR DESCRIPTION
Fixes #270 

note: untested, but it should provide output sufficient for `lighthouse validator-manager import` which is a good target motivating #270 
