### PR TITLE
improvement to type-gen, if type is copy, just return directly

### DIFF
--- a/ethereum-consensus/src/types/beacon_block.rs
+++ b/ethereum-consensus/src/types/beacon_block.rs
@@ -354,76 +354,40 @@ impl<
             Self::Deneb(_) => Version::Deneb,
         }
     }
-    pub fn slot(&self) -> &Slot {
+    pub fn slot(&self) -> Slot {
         match self {
-            Self::Phase0(inner) => &inner.slot,
-            Self::Altair(inner) => &inner.slot,
-            Self::Bellatrix(inner) => &inner.slot,
-            Self::Capella(inner) => &inner.slot,
-            Self::Deneb(inner) => &inner.slot,
+            Self::Phase0(inner) => inner.slot,
+            Self::Altair(inner) => inner.slot,
+            Self::Bellatrix(inner) => inner.slot,
+            Self::Capella(inner) => inner.slot,
+            Self::Deneb(inner) => inner.slot,
         }
     }
-    pub fn slot_mut(&mut self) -> &mut Slot {
+    pub fn proposer_index(&self) -> ValidatorIndex {
         match self {
-            Self::Phase0(inner) => &mut inner.slot,
-            Self::Altair(inner) => &mut inner.slot,
-            Self::Bellatrix(inner) => &mut inner.slot,
-            Self::Capella(inner) => &mut inner.slot,
-            Self::Deneb(inner) => &mut inner.slot,
+            Self::Phase0(inner) => inner.proposer_index,
+            Self::Altair(inner) => inner.proposer_index,
+            Self::Bellatrix(inner) => inner.proposer_index,
+            Self::Capella(inner) => inner.proposer_index,
+            Self::Deneb(inner) => inner.proposer_index,
         }
     }
-    pub fn proposer_index(&self) -> &ValidatorIndex {
+    pub fn parent_root(&self) -> Root {
         match self {
-            Self::Phase0(inner) => &inner.proposer_index,
-            Self::Altair(inner) => &inner.proposer_index,
-            Self::Bellatrix(inner) => &inner.proposer_index,
-            Self::Capella(inner) => &inner.proposer_index,
-            Self::Deneb(inner) => &inner.proposer_index,
+            Self::Phase0(inner) => inner.parent_root,
+            Self::Altair(inner) => inner.parent_root,
+            Self::Bellatrix(inner) => inner.parent_root,
+            Self::Capella(inner) => inner.parent_root,
+            Self::Deneb(inner) => inner.parent_root,
         }
     }
-    pub fn proposer_index_mut(&mut self) -> &mut ValidatorIndex {
+    pub fn state_root(&self) -> Root {
         match self {
-            Self::Phase0(inner) => &mut inner.proposer_index,
-            Self::Altair(inner) => &mut inner.proposer_index,
-            Self::Bellatrix(inner) => &mut inner.proposer_index,
-            Self::Capella(inner) => &mut inner.proposer_index,
-            Self::Deneb(inner) => &mut inner.proposer_index,
-        }
-    }
-    pub fn parent_root(&self) -> &Root {
-        match self {
-            Self::Phase0(inner) => &inner.parent_root,
-            Self::Altair(inner) => &inner.parent_root,
-            Self::Bellatrix(inner) => &inner.parent_root,
-            Self::Capella(inner) => &inner.parent_root,
-            Self::Deneb(inner) => &inner.parent_root,
-        }
-    }
-    pub fn parent_root_mut(&mut self) -> &mut Root {
-        match self {
-            Self::Phase0(inner) => &mut inner.parent_root,
-            Self::Altair(inner) => &mut inner.parent_root,
-            Self::Bellatrix(inner) => &mut inner.parent_root,
-            Self::Capella(inner) => &mut inner.parent_root,
-            Self::Deneb(inner) => &mut inner.parent_root,
-        }
-    }
-    pub fn state_root(&self) -> &Root {
-        match self {
-            Self::Phase0(inner) => &inner.state_root,
-            Self::Altair(inner) => &inner.state_root,
-            Self::Bellatrix(inner) => &inner.state_root,
-            Self::Capella(inner) => &inner.state_root,
-            Self::Deneb(inner) => &inner.state_root,
-        }
-    }
-    pub fn state_root_mut(&mut self) -> &mut Root {
-        match self {
-            Self::Phase0(inner) => &mut inner.state_root,
-            Self::Altair(inner) => &mut inner.state_root,
-            Self::Bellatrix(inner) => &mut inner.state_root,
-            Self::Capella(inner) => &mut inner.state_root,
-            Self::Deneb(inner) => &mut inner.state_root,
+            Self::Phase0(inner) => inner.state_root,
+            Self::Altair(inner) => inner.state_root,
+            Self::Bellatrix(inner) => inner.state_root,
+            Self::Capella(inner) => inner.state_root,
+            Self::Deneb(inner) => inner.state_root,
         }
     }
     pub fn body(
@@ -776,40 +740,40 @@ impl<
             Self::Deneb(_) => Version::Deneb,
         }
     }
-    pub fn slot(&self) -> &Slot {
+    pub fn slot(&self) -> Slot {
         match self {
-            Self::Phase0(inner) => &inner.slot,
-            Self::Altair(inner) => &inner.slot,
-            Self::Bellatrix(inner) => &inner.slot,
-            Self::Capella(inner) => &inner.slot,
-            Self::Deneb(inner) => &inner.slot,
+            Self::Phase0(inner) => inner.slot,
+            Self::Altair(inner) => inner.slot,
+            Self::Bellatrix(inner) => inner.slot,
+            Self::Capella(inner) => inner.slot,
+            Self::Deneb(inner) => inner.slot,
         }
     }
-    pub fn proposer_index(&self) -> &ValidatorIndex {
+    pub fn proposer_index(&self) -> ValidatorIndex {
         match self {
-            Self::Phase0(inner) => &inner.proposer_index,
-            Self::Altair(inner) => &inner.proposer_index,
-            Self::Bellatrix(inner) => &inner.proposer_index,
-            Self::Capella(inner) => &inner.proposer_index,
-            Self::Deneb(inner) => &inner.proposer_index,
+            Self::Phase0(inner) => inner.proposer_index,
+            Self::Altair(inner) => inner.proposer_index,
+            Self::Bellatrix(inner) => inner.proposer_index,
+            Self::Capella(inner) => inner.proposer_index,
+            Self::Deneb(inner) => inner.proposer_index,
         }
     }
-    pub fn parent_root(&self) -> &Root {
+    pub fn parent_root(&self) -> Root {
         match self {
-            Self::Phase0(inner) => &inner.parent_root,
-            Self::Altair(inner) => &inner.parent_root,
-            Self::Bellatrix(inner) => &inner.parent_root,
-            Self::Capella(inner) => &inner.parent_root,
-            Self::Deneb(inner) => &inner.parent_root,
+            Self::Phase0(inner) => inner.parent_root,
+            Self::Altair(inner) => inner.parent_root,
+            Self::Bellatrix(inner) => inner.parent_root,
+            Self::Capella(inner) => inner.parent_root,
+            Self::Deneb(inner) => inner.parent_root,
         }
     }
-    pub fn state_root(&self) -> &Root {
+    pub fn state_root(&self) -> Root {
         match self {
-            Self::Phase0(inner) => &inner.state_root,
-            Self::Altair(inner) => &inner.state_root,
-            Self::Bellatrix(inner) => &inner.state_root,
-            Self::Capella(inner) => &inner.state_root,
-            Self::Deneb(inner) => &inner.state_root,
+            Self::Phase0(inner) => inner.state_root,
+            Self::Altair(inner) => inner.state_root,
+            Self::Bellatrix(inner) => inner.state_root,
+            Self::Capella(inner) => inner.state_root,
+            Self::Deneb(inner) => inner.state_root,
         }
     }
     pub fn body(
@@ -1518,76 +1482,40 @@ impl<
             Self::Deneb(_) => Version::Deneb,
         }
     }
-    pub fn slot(&self) -> &Slot {
+    pub fn slot(&self) -> Slot {
         match self {
-            Self::Phase0(inner) => &inner.slot,
-            Self::Altair(inner) => &inner.slot,
-            Self::Bellatrix(inner) => &inner.slot,
-            Self::Capella(inner) => &inner.slot,
-            Self::Deneb(inner) => &inner.slot,
+            Self::Phase0(inner) => inner.slot,
+            Self::Altair(inner) => inner.slot,
+            Self::Bellatrix(inner) => inner.slot,
+            Self::Capella(inner) => inner.slot,
+            Self::Deneb(inner) => inner.slot,
         }
     }
-    pub fn slot_mut(&mut self) -> &mut Slot {
+    pub fn proposer_index(&self) -> ValidatorIndex {
         match self {
-            Self::Phase0(inner) => &mut inner.slot,
-            Self::Altair(inner) => &mut inner.slot,
-            Self::Bellatrix(inner) => &mut inner.slot,
-            Self::Capella(inner) => &mut inner.slot,
-            Self::Deneb(inner) => &mut inner.slot,
+            Self::Phase0(inner) => inner.proposer_index,
+            Self::Altair(inner) => inner.proposer_index,
+            Self::Bellatrix(inner) => inner.proposer_index,
+            Self::Capella(inner) => inner.proposer_index,
+            Self::Deneb(inner) => inner.proposer_index,
         }
     }
-    pub fn proposer_index(&self) -> &ValidatorIndex {
+    pub fn parent_root(&self) -> Root {
         match self {
-            Self::Phase0(inner) => &inner.proposer_index,
-            Self::Altair(inner) => &inner.proposer_index,
-            Self::Bellatrix(inner) => &inner.proposer_index,
-            Self::Capella(inner) => &inner.proposer_index,
-            Self::Deneb(inner) => &inner.proposer_index,
+            Self::Phase0(inner) => inner.parent_root,
+            Self::Altair(inner) => inner.parent_root,
+            Self::Bellatrix(inner) => inner.parent_root,
+            Self::Capella(inner) => inner.parent_root,
+            Self::Deneb(inner) => inner.parent_root,
         }
     }
-    pub fn proposer_index_mut(&mut self) -> &mut ValidatorIndex {
+    pub fn state_root(&self) -> Root {
         match self {
-            Self::Phase0(inner) => &mut inner.proposer_index,
-            Self::Altair(inner) => &mut inner.proposer_index,
-            Self::Bellatrix(inner) => &mut inner.proposer_index,
-            Self::Capella(inner) => &mut inner.proposer_index,
-            Self::Deneb(inner) => &mut inner.proposer_index,
-        }
-    }
-    pub fn parent_root(&self) -> &Root {
-        match self {
-            Self::Phase0(inner) => &inner.parent_root,
-            Self::Altair(inner) => &inner.parent_root,
-            Self::Bellatrix(inner) => &inner.parent_root,
-            Self::Capella(inner) => &inner.parent_root,
-            Self::Deneb(inner) => &inner.parent_root,
-        }
-    }
-    pub fn parent_root_mut(&mut self) -> &mut Root {
-        match self {
-            Self::Phase0(inner) => &mut inner.parent_root,
-            Self::Altair(inner) => &mut inner.parent_root,
-            Self::Bellatrix(inner) => &mut inner.parent_root,
-            Self::Capella(inner) => &mut inner.parent_root,
-            Self::Deneb(inner) => &mut inner.parent_root,
-        }
-    }
-    pub fn state_root(&self) -> &Root {
-        match self {
-            Self::Phase0(inner) => &inner.state_root,
-            Self::Altair(inner) => &inner.state_root,
-            Self::Bellatrix(inner) => &inner.state_root,
-            Self::Capella(inner) => &inner.state_root,
-            Self::Deneb(inner) => &inner.state_root,
-        }
-    }
-    pub fn state_root_mut(&mut self) -> &mut Root {
-        match self {
-            Self::Phase0(inner) => &mut inner.state_root,
-            Self::Altair(inner) => &mut inner.state_root,
-            Self::Bellatrix(inner) => &mut inner.state_root,
-            Self::Capella(inner) => &mut inner.state_root,
-            Self::Deneb(inner) => &mut inner.state_root,
+            Self::Phase0(inner) => inner.state_root,
+            Self::Altair(inner) => inner.state_root,
+            Self::Bellatrix(inner) => inner.state_root,
+            Self::Capella(inner) => inner.state_root,
+            Self::Deneb(inner) => inner.state_root,
         }
     }
     pub fn body(

--- a/ethereum-consensus/src/types/beacon_state.rs
+++ b/ethereum-consensus/src/types/beacon_state.rs
@@ -336,58 +336,31 @@ impl<
             Self::Deneb(_) => Version::Deneb,
         }
     }
-    pub fn genesis_time(&self) -> &u64 {
+    pub fn genesis_time(&self) -> u64 {
         match self {
-            Self::Phase0(inner) => &inner.genesis_time,
-            Self::Altair(inner) => &inner.genesis_time,
-            Self::Bellatrix(inner) => &inner.genesis_time,
-            Self::Capella(inner) => &inner.genesis_time,
-            Self::Deneb(inner) => &inner.genesis_time,
+            Self::Phase0(inner) => inner.genesis_time,
+            Self::Altair(inner) => inner.genesis_time,
+            Self::Bellatrix(inner) => inner.genesis_time,
+            Self::Capella(inner) => inner.genesis_time,
+            Self::Deneb(inner) => inner.genesis_time,
         }
     }
-    pub fn genesis_time_mut(&mut self) -> &mut u64 {
+    pub fn genesis_validators_root(&self) -> Root {
         match self {
-            Self::Phase0(inner) => &mut inner.genesis_time,
-            Self::Altair(inner) => &mut inner.genesis_time,
-            Self::Bellatrix(inner) => &mut inner.genesis_time,
-            Self::Capella(inner) => &mut inner.genesis_time,
-            Self::Deneb(inner) => &mut inner.genesis_time,
+            Self::Phase0(inner) => inner.genesis_validators_root,
+            Self::Altair(inner) => inner.genesis_validators_root,
+            Self::Bellatrix(inner) => inner.genesis_validators_root,
+            Self::Capella(inner) => inner.genesis_validators_root,
+            Self::Deneb(inner) => inner.genesis_validators_root,
         }
     }
-    pub fn genesis_validators_root(&self) -> &Root {
+    pub fn slot(&self) -> Slot {
         match self {
-            Self::Phase0(inner) => &inner.genesis_validators_root,
-            Self::Altair(inner) => &inner.genesis_validators_root,
-            Self::Bellatrix(inner) => &inner.genesis_validators_root,
-            Self::Capella(inner) => &inner.genesis_validators_root,
-            Self::Deneb(inner) => &inner.genesis_validators_root,
-        }
-    }
-    pub fn genesis_validators_root_mut(&mut self) -> &mut Root {
-        match self {
-            Self::Phase0(inner) => &mut inner.genesis_validators_root,
-            Self::Altair(inner) => &mut inner.genesis_validators_root,
-            Self::Bellatrix(inner) => &mut inner.genesis_validators_root,
-            Self::Capella(inner) => &mut inner.genesis_validators_root,
-            Self::Deneb(inner) => &mut inner.genesis_validators_root,
-        }
-    }
-    pub fn slot(&self) -> &Slot {
-        match self {
-            Self::Phase0(inner) => &inner.slot,
-            Self::Altair(inner) => &inner.slot,
-            Self::Bellatrix(inner) => &inner.slot,
-            Self::Capella(inner) => &inner.slot,
-            Self::Deneb(inner) => &inner.slot,
-        }
-    }
-    pub fn slot_mut(&mut self) -> &mut Slot {
-        match self {
-            Self::Phase0(inner) => &mut inner.slot,
-            Self::Altair(inner) => &mut inner.slot,
-            Self::Bellatrix(inner) => &mut inner.slot,
-            Self::Capella(inner) => &mut inner.slot,
-            Self::Deneb(inner) => &mut inner.slot,
+            Self::Phase0(inner) => inner.slot,
+            Self::Altair(inner) => inner.slot,
+            Self::Bellatrix(inner) => inner.slot,
+            Self::Capella(inner) => inner.slot,
+            Self::Deneb(inner) => inner.slot,
         }
     }
     pub fn fork(&self) -> &Fork {
@@ -516,22 +489,13 @@ impl<
             Self::Deneb(inner) => &mut inner.eth1_data_votes,
         }
     }
-    pub fn eth1_deposit_index(&self) -> &u64 {
+    pub fn eth1_deposit_index(&self) -> u64 {
         match self {
-            Self::Phase0(inner) => &inner.eth1_deposit_index,
-            Self::Altair(inner) => &inner.eth1_deposit_index,
-            Self::Bellatrix(inner) => &inner.eth1_deposit_index,
-            Self::Capella(inner) => &inner.eth1_deposit_index,
-            Self::Deneb(inner) => &inner.eth1_deposit_index,
-        }
-    }
-    pub fn eth1_deposit_index_mut(&mut self) -> &mut u64 {
-        match self {
-            Self::Phase0(inner) => &mut inner.eth1_deposit_index,
-            Self::Altair(inner) => &mut inner.eth1_deposit_index,
-            Self::Bellatrix(inner) => &mut inner.eth1_deposit_index,
-            Self::Capella(inner) => &mut inner.eth1_deposit_index,
-            Self::Deneb(inner) => &mut inner.eth1_deposit_index,
+            Self::Phase0(inner) => inner.eth1_deposit_index,
+            Self::Altair(inner) => inner.eth1_deposit_index,
+            Self::Bellatrix(inner) => inner.eth1_deposit_index,
+            Self::Capella(inner) => inner.eth1_deposit_index,
+            Self::Deneb(inner) => inner.eth1_deposit_index,
         }
     }
     pub fn validators(&self) -> &List<Validator, VALIDATOR_REGISTRY_LIMIT> {
@@ -850,40 +814,22 @@ impl<
             Self::Deneb(inner) => Some(From::from(&mut inner.latest_execution_payload_header)),
         }
     }
-    pub fn next_withdrawal_index(&self) -> Option<&WithdrawalIndex> {
+    pub fn next_withdrawal_index(&self) -> Option<WithdrawalIndex> {
         match self {
             Self::Phase0(_) => None,
             Self::Altair(_) => None,
             Self::Bellatrix(_) => None,
-            Self::Capella(inner) => Some(&inner.next_withdrawal_index),
-            Self::Deneb(inner) => Some(&inner.next_withdrawal_index),
+            Self::Capella(inner) => Some(inner.next_withdrawal_index),
+            Self::Deneb(inner) => Some(inner.next_withdrawal_index),
         }
     }
-    pub fn next_withdrawal_index_mut(&mut self) -> Option<&mut WithdrawalIndex> {
+    pub fn next_withdrawal_validator_index(&self) -> Option<ValidatorIndex> {
         match self {
             Self::Phase0(_) => None,
             Self::Altair(_) => None,
             Self::Bellatrix(_) => None,
-            Self::Capella(inner) => Some(&mut inner.next_withdrawal_index),
-            Self::Deneb(inner) => Some(&mut inner.next_withdrawal_index),
-        }
-    }
-    pub fn next_withdrawal_validator_index(&self) -> Option<&ValidatorIndex> {
-        match self {
-            Self::Phase0(_) => None,
-            Self::Altair(_) => None,
-            Self::Bellatrix(_) => None,
-            Self::Capella(inner) => Some(&inner.next_withdrawal_validator_index),
-            Self::Deneb(inner) => Some(&inner.next_withdrawal_validator_index),
-        }
-    }
-    pub fn next_withdrawal_validator_index_mut(&mut self) -> Option<&mut ValidatorIndex> {
-        match self {
-            Self::Phase0(_) => None,
-            Self::Altair(_) => None,
-            Self::Bellatrix(_) => None,
-            Self::Capella(inner) => Some(&mut inner.next_withdrawal_validator_index),
-            Self::Deneb(inner) => Some(&mut inner.next_withdrawal_validator_index),
+            Self::Capella(inner) => Some(inner.next_withdrawal_validator_index),
+            Self::Deneb(inner) => Some(inner.next_withdrawal_validator_index),
         }
     }
     pub fn historical_summaries(&self) -> Option<&List<HistoricalSummary, HISTORICAL_ROOTS_LIMIT>> {
@@ -1179,31 +1125,31 @@ impl<
             Self::Deneb(_) => Version::Deneb,
         }
     }
-    pub fn genesis_time(&self) -> &u64 {
+    pub fn genesis_time(&self) -> u64 {
         match self {
-            Self::Phase0(inner) => &inner.genesis_time,
-            Self::Altair(inner) => &inner.genesis_time,
-            Self::Bellatrix(inner) => &inner.genesis_time,
-            Self::Capella(inner) => &inner.genesis_time,
-            Self::Deneb(inner) => &inner.genesis_time,
+            Self::Phase0(inner) => inner.genesis_time,
+            Self::Altair(inner) => inner.genesis_time,
+            Self::Bellatrix(inner) => inner.genesis_time,
+            Self::Capella(inner) => inner.genesis_time,
+            Self::Deneb(inner) => inner.genesis_time,
         }
     }
-    pub fn genesis_validators_root(&self) -> &Root {
+    pub fn genesis_validators_root(&self) -> Root {
         match self {
-            Self::Phase0(inner) => &inner.genesis_validators_root,
-            Self::Altair(inner) => &inner.genesis_validators_root,
-            Self::Bellatrix(inner) => &inner.genesis_validators_root,
-            Self::Capella(inner) => &inner.genesis_validators_root,
-            Self::Deneb(inner) => &inner.genesis_validators_root,
+            Self::Phase0(inner) => inner.genesis_validators_root,
+            Self::Altair(inner) => inner.genesis_validators_root,
+            Self::Bellatrix(inner) => inner.genesis_validators_root,
+            Self::Capella(inner) => inner.genesis_validators_root,
+            Self::Deneb(inner) => inner.genesis_validators_root,
         }
     }
-    pub fn slot(&self) -> &Slot {
+    pub fn slot(&self) -> Slot {
         match self {
-            Self::Phase0(inner) => &inner.slot,
-            Self::Altair(inner) => &inner.slot,
-            Self::Bellatrix(inner) => &inner.slot,
-            Self::Capella(inner) => &inner.slot,
-            Self::Deneb(inner) => &inner.slot,
+            Self::Phase0(inner) => inner.slot,
+            Self::Altair(inner) => inner.slot,
+            Self::Bellatrix(inner) => inner.slot,
+            Self::Capella(inner) => inner.slot,
+            Self::Deneb(inner) => inner.slot,
         }
     }
     pub fn fork(&self) -> &Fork {
@@ -1269,13 +1215,13 @@ impl<
             Self::Deneb(inner) => &inner.eth1_data_votes,
         }
     }
-    pub fn eth1_deposit_index(&self) -> &u64 {
+    pub fn eth1_deposit_index(&self) -> u64 {
         match self {
-            Self::Phase0(inner) => &inner.eth1_deposit_index,
-            Self::Altair(inner) => &inner.eth1_deposit_index,
-            Self::Bellatrix(inner) => &inner.eth1_deposit_index,
-            Self::Capella(inner) => &inner.eth1_deposit_index,
-            Self::Deneb(inner) => &inner.eth1_deposit_index,
+            Self::Phase0(inner) => inner.eth1_deposit_index,
+            Self::Altair(inner) => inner.eth1_deposit_index,
+            Self::Bellatrix(inner) => inner.eth1_deposit_index,
+            Self::Capella(inner) => inner.eth1_deposit_index,
+            Self::Deneb(inner) => inner.eth1_deposit_index,
         }
     }
     pub fn validators(&self) -> &List<Validator, VALIDATOR_REGISTRY_LIMIT> {
@@ -1434,22 +1380,22 @@ impl<
             Self::Deneb(inner) => Some(From::from(&inner.latest_execution_payload_header)),
         }
     }
-    pub fn next_withdrawal_index(&self) -> Option<&WithdrawalIndex> {
+    pub fn next_withdrawal_index(&self) -> Option<WithdrawalIndex> {
         match self {
             Self::Phase0(_) => None,
             Self::Altair(_) => None,
             Self::Bellatrix(_) => None,
-            Self::Capella(inner) => Some(&inner.next_withdrawal_index),
-            Self::Deneb(inner) => Some(&inner.next_withdrawal_index),
+            Self::Capella(inner) => Some(inner.next_withdrawal_index),
+            Self::Deneb(inner) => Some(inner.next_withdrawal_index),
         }
     }
-    pub fn next_withdrawal_validator_index(&self) -> Option<&ValidatorIndex> {
+    pub fn next_withdrawal_validator_index(&self) -> Option<ValidatorIndex> {
         match self {
             Self::Phase0(_) => None,
             Self::Altair(_) => None,
             Self::Bellatrix(_) => None,
-            Self::Capella(inner) => Some(&inner.next_withdrawal_validator_index),
-            Self::Deneb(inner) => Some(&inner.next_withdrawal_validator_index),
+            Self::Capella(inner) => Some(inner.next_withdrawal_validator_index),
+            Self::Deneb(inner) => Some(inner.next_withdrawal_validator_index),
         }
     }
     pub fn historical_summaries(&self) -> Option<&List<HistoricalSummary, HISTORICAL_ROOTS_LIMIT>> {
@@ -2077,58 +2023,31 @@ impl<
             Self::Deneb(_) => Version::Deneb,
         }
     }
-    pub fn genesis_time(&self) -> &u64 {
+    pub fn genesis_time(&self) -> u64 {
         match self {
-            Self::Phase0(inner) => &inner.genesis_time,
-            Self::Altair(inner) => &inner.genesis_time,
-            Self::Bellatrix(inner) => &inner.genesis_time,
-            Self::Capella(inner) => &inner.genesis_time,
-            Self::Deneb(inner) => &inner.genesis_time,
+            Self::Phase0(inner) => inner.genesis_time,
+            Self::Altair(inner) => inner.genesis_time,
+            Self::Bellatrix(inner) => inner.genesis_time,
+            Self::Capella(inner) => inner.genesis_time,
+            Self::Deneb(inner) => inner.genesis_time,
         }
     }
-    pub fn genesis_time_mut(&mut self) -> &mut u64 {
+    pub fn genesis_validators_root(&self) -> Root {
         match self {
-            Self::Phase0(inner) => &mut inner.genesis_time,
-            Self::Altair(inner) => &mut inner.genesis_time,
-            Self::Bellatrix(inner) => &mut inner.genesis_time,
-            Self::Capella(inner) => &mut inner.genesis_time,
-            Self::Deneb(inner) => &mut inner.genesis_time,
+            Self::Phase0(inner) => inner.genesis_validators_root,
+            Self::Altair(inner) => inner.genesis_validators_root,
+            Self::Bellatrix(inner) => inner.genesis_validators_root,
+            Self::Capella(inner) => inner.genesis_validators_root,
+            Self::Deneb(inner) => inner.genesis_validators_root,
         }
     }
-    pub fn genesis_validators_root(&self) -> &Root {
+    pub fn slot(&self) -> Slot {
         match self {
-            Self::Phase0(inner) => &inner.genesis_validators_root,
-            Self::Altair(inner) => &inner.genesis_validators_root,
-            Self::Bellatrix(inner) => &inner.genesis_validators_root,
-            Self::Capella(inner) => &inner.genesis_validators_root,
-            Self::Deneb(inner) => &inner.genesis_validators_root,
-        }
-    }
-    pub fn genesis_validators_root_mut(&mut self) -> &mut Root {
-        match self {
-            Self::Phase0(inner) => &mut inner.genesis_validators_root,
-            Self::Altair(inner) => &mut inner.genesis_validators_root,
-            Self::Bellatrix(inner) => &mut inner.genesis_validators_root,
-            Self::Capella(inner) => &mut inner.genesis_validators_root,
-            Self::Deneb(inner) => &mut inner.genesis_validators_root,
-        }
-    }
-    pub fn slot(&self) -> &Slot {
-        match self {
-            Self::Phase0(inner) => &inner.slot,
-            Self::Altair(inner) => &inner.slot,
-            Self::Bellatrix(inner) => &inner.slot,
-            Self::Capella(inner) => &inner.slot,
-            Self::Deneb(inner) => &inner.slot,
-        }
-    }
-    pub fn slot_mut(&mut self) -> &mut Slot {
-        match self {
-            Self::Phase0(inner) => &mut inner.slot,
-            Self::Altair(inner) => &mut inner.slot,
-            Self::Bellatrix(inner) => &mut inner.slot,
-            Self::Capella(inner) => &mut inner.slot,
-            Self::Deneb(inner) => &mut inner.slot,
+            Self::Phase0(inner) => inner.slot,
+            Self::Altair(inner) => inner.slot,
+            Self::Bellatrix(inner) => inner.slot,
+            Self::Capella(inner) => inner.slot,
+            Self::Deneb(inner) => inner.slot,
         }
     }
     pub fn fork(&self) -> &Fork {
@@ -2257,22 +2176,13 @@ impl<
             Self::Deneb(inner) => &mut inner.eth1_data_votes,
         }
     }
-    pub fn eth1_deposit_index(&self) -> &u64 {
+    pub fn eth1_deposit_index(&self) -> u64 {
         match self {
-            Self::Phase0(inner) => &inner.eth1_deposit_index,
-            Self::Altair(inner) => &inner.eth1_deposit_index,
-            Self::Bellatrix(inner) => &inner.eth1_deposit_index,
-            Self::Capella(inner) => &inner.eth1_deposit_index,
-            Self::Deneb(inner) => &inner.eth1_deposit_index,
-        }
-    }
-    pub fn eth1_deposit_index_mut(&mut self) -> &mut u64 {
-        match self {
-            Self::Phase0(inner) => &mut inner.eth1_deposit_index,
-            Self::Altair(inner) => &mut inner.eth1_deposit_index,
-            Self::Bellatrix(inner) => &mut inner.eth1_deposit_index,
-            Self::Capella(inner) => &mut inner.eth1_deposit_index,
-            Self::Deneb(inner) => &mut inner.eth1_deposit_index,
+            Self::Phase0(inner) => inner.eth1_deposit_index,
+            Self::Altair(inner) => inner.eth1_deposit_index,
+            Self::Bellatrix(inner) => inner.eth1_deposit_index,
+            Self::Capella(inner) => inner.eth1_deposit_index,
+            Self::Deneb(inner) => inner.eth1_deposit_index,
         }
     }
     pub fn validators(&self) -> &List<Validator, VALIDATOR_REGISTRY_LIMIT> {
@@ -2591,40 +2501,22 @@ impl<
             Self::Deneb(inner) => Some(From::from(&mut inner.latest_execution_payload_header)),
         }
     }
-    pub fn next_withdrawal_index(&self) -> Option<&WithdrawalIndex> {
+    pub fn next_withdrawal_index(&self) -> Option<WithdrawalIndex> {
         match self {
             Self::Phase0(_) => None,
             Self::Altair(_) => None,
             Self::Bellatrix(_) => None,
-            Self::Capella(inner) => Some(&inner.next_withdrawal_index),
-            Self::Deneb(inner) => Some(&inner.next_withdrawal_index),
+            Self::Capella(inner) => Some(inner.next_withdrawal_index),
+            Self::Deneb(inner) => Some(inner.next_withdrawal_index),
         }
     }
-    pub fn next_withdrawal_index_mut(&mut self) -> Option<&mut WithdrawalIndex> {
+    pub fn next_withdrawal_validator_index(&self) -> Option<ValidatorIndex> {
         match self {
             Self::Phase0(_) => None,
             Self::Altair(_) => None,
             Self::Bellatrix(_) => None,
-            Self::Capella(inner) => Some(&mut inner.next_withdrawal_index),
-            Self::Deneb(inner) => Some(&mut inner.next_withdrawal_index),
-        }
-    }
-    pub fn next_withdrawal_validator_index(&self) -> Option<&ValidatorIndex> {
-        match self {
-            Self::Phase0(_) => None,
-            Self::Altair(_) => None,
-            Self::Bellatrix(_) => None,
-            Self::Capella(inner) => Some(&inner.next_withdrawal_validator_index),
-            Self::Deneb(inner) => Some(&inner.next_withdrawal_validator_index),
-        }
-    }
-    pub fn next_withdrawal_validator_index_mut(&mut self) -> Option<&mut ValidatorIndex> {
-        match self {
-            Self::Phase0(_) => None,
-            Self::Altair(_) => None,
-            Self::Bellatrix(_) => None,
-            Self::Capella(inner) => Some(&mut inner.next_withdrawal_validator_index),
-            Self::Deneb(inner) => Some(&mut inner.next_withdrawal_validator_index),
+            Self::Capella(inner) => Some(inner.next_withdrawal_validator_index),
+            Self::Deneb(inner) => Some(inner.next_withdrawal_validator_index),
         }
     }
     pub fn historical_summaries(&self) -> Option<&List<HistoricalSummary, HISTORICAL_ROOTS_LIMIT>> {

--- a/ethereum-consensus/src/types/blinded_beacon_block.rs
+++ b/ethereum-consensus/src/types/blinded_beacon_block.rs
@@ -226,60 +226,32 @@ impl<
             Self::Deneb(_) => Version::Deneb,
         }
     }
-    pub fn slot(&self) -> &Slot {
+    pub fn slot(&self) -> Slot {
         match self {
-            Self::Bellatrix(inner) => &inner.slot,
-            Self::Capella(inner) => &inner.slot,
-            Self::Deneb(inner) => &inner.slot,
+            Self::Bellatrix(inner) => inner.slot,
+            Self::Capella(inner) => inner.slot,
+            Self::Deneb(inner) => inner.slot,
         }
     }
-    pub fn slot_mut(&mut self) -> &mut Slot {
+    pub fn proposer_index(&self) -> ValidatorIndex {
         match self {
-            Self::Bellatrix(inner) => &mut inner.slot,
-            Self::Capella(inner) => &mut inner.slot,
-            Self::Deneb(inner) => &mut inner.slot,
+            Self::Bellatrix(inner) => inner.proposer_index,
+            Self::Capella(inner) => inner.proposer_index,
+            Self::Deneb(inner) => inner.proposer_index,
         }
     }
-    pub fn proposer_index(&self) -> &ValidatorIndex {
+    pub fn parent_root(&self) -> Root {
         match self {
-            Self::Bellatrix(inner) => &inner.proposer_index,
-            Self::Capella(inner) => &inner.proposer_index,
-            Self::Deneb(inner) => &inner.proposer_index,
+            Self::Bellatrix(inner) => inner.parent_root,
+            Self::Capella(inner) => inner.parent_root,
+            Self::Deneb(inner) => inner.parent_root,
         }
     }
-    pub fn proposer_index_mut(&mut self) -> &mut ValidatorIndex {
+    pub fn state_root(&self) -> Root {
         match self {
-            Self::Bellatrix(inner) => &mut inner.proposer_index,
-            Self::Capella(inner) => &mut inner.proposer_index,
-            Self::Deneb(inner) => &mut inner.proposer_index,
-        }
-    }
-    pub fn parent_root(&self) -> &Root {
-        match self {
-            Self::Bellatrix(inner) => &inner.parent_root,
-            Self::Capella(inner) => &inner.parent_root,
-            Self::Deneb(inner) => &inner.parent_root,
-        }
-    }
-    pub fn parent_root_mut(&mut self) -> &mut Root {
-        match self {
-            Self::Bellatrix(inner) => &mut inner.parent_root,
-            Self::Capella(inner) => &mut inner.parent_root,
-            Self::Deneb(inner) => &mut inner.parent_root,
-        }
-    }
-    pub fn state_root(&self) -> &Root {
-        match self {
-            Self::Bellatrix(inner) => &inner.state_root,
-            Self::Capella(inner) => &inner.state_root,
-            Self::Deneb(inner) => &inner.state_root,
-        }
-    }
-    pub fn state_root_mut(&mut self) -> &mut Root {
-        match self {
-            Self::Bellatrix(inner) => &mut inner.state_root,
-            Self::Capella(inner) => &mut inner.state_root,
-            Self::Deneb(inner) => &mut inner.state_root,
+            Self::Bellatrix(inner) => inner.state_root,
+            Self::Capella(inner) => inner.state_root,
+            Self::Deneb(inner) => inner.state_root,
         }
     }
     pub fn body(
@@ -527,32 +499,32 @@ impl<
             Self::Deneb(_) => Version::Deneb,
         }
     }
-    pub fn slot(&self) -> &Slot {
+    pub fn slot(&self) -> Slot {
         match self {
-            Self::Bellatrix(inner) => &inner.slot,
-            Self::Capella(inner) => &inner.slot,
-            Self::Deneb(inner) => &inner.slot,
+            Self::Bellatrix(inner) => inner.slot,
+            Self::Capella(inner) => inner.slot,
+            Self::Deneb(inner) => inner.slot,
         }
     }
-    pub fn proposer_index(&self) -> &ValidatorIndex {
+    pub fn proposer_index(&self) -> ValidatorIndex {
         match self {
-            Self::Bellatrix(inner) => &inner.proposer_index,
-            Self::Capella(inner) => &inner.proposer_index,
-            Self::Deneb(inner) => &inner.proposer_index,
+            Self::Bellatrix(inner) => inner.proposer_index,
+            Self::Capella(inner) => inner.proposer_index,
+            Self::Deneb(inner) => inner.proposer_index,
         }
     }
-    pub fn parent_root(&self) -> &Root {
+    pub fn parent_root(&self) -> Root {
         match self {
-            Self::Bellatrix(inner) => &inner.parent_root,
-            Self::Capella(inner) => &inner.parent_root,
-            Self::Deneb(inner) => &inner.parent_root,
+            Self::Bellatrix(inner) => inner.parent_root,
+            Self::Capella(inner) => inner.parent_root,
+            Self::Deneb(inner) => inner.parent_root,
         }
     }
-    pub fn state_root(&self) -> &Root {
+    pub fn state_root(&self) -> Root {
         match self {
-            Self::Bellatrix(inner) => &inner.state_root,
-            Self::Capella(inner) => &inner.state_root,
-            Self::Deneb(inner) => &inner.state_root,
+            Self::Bellatrix(inner) => inner.state_root,
+            Self::Capella(inner) => inner.state_root,
+            Self::Deneb(inner) => inner.state_root,
         }
     }
     pub fn body(
@@ -978,60 +950,32 @@ impl<
             Self::Deneb(_) => Version::Deneb,
         }
     }
-    pub fn slot(&self) -> &Slot {
+    pub fn slot(&self) -> Slot {
         match self {
-            Self::Bellatrix(inner) => &inner.slot,
-            Self::Capella(inner) => &inner.slot,
-            Self::Deneb(inner) => &inner.slot,
+            Self::Bellatrix(inner) => inner.slot,
+            Self::Capella(inner) => inner.slot,
+            Self::Deneb(inner) => inner.slot,
         }
     }
-    pub fn slot_mut(&mut self) -> &mut Slot {
+    pub fn proposer_index(&self) -> ValidatorIndex {
         match self {
-            Self::Bellatrix(inner) => &mut inner.slot,
-            Self::Capella(inner) => &mut inner.slot,
-            Self::Deneb(inner) => &mut inner.slot,
+            Self::Bellatrix(inner) => inner.proposer_index,
+            Self::Capella(inner) => inner.proposer_index,
+            Self::Deneb(inner) => inner.proposer_index,
         }
     }
-    pub fn proposer_index(&self) -> &ValidatorIndex {
+    pub fn parent_root(&self) -> Root {
         match self {
-            Self::Bellatrix(inner) => &inner.proposer_index,
-            Self::Capella(inner) => &inner.proposer_index,
-            Self::Deneb(inner) => &inner.proposer_index,
+            Self::Bellatrix(inner) => inner.parent_root,
+            Self::Capella(inner) => inner.parent_root,
+            Self::Deneb(inner) => inner.parent_root,
         }
     }
-    pub fn proposer_index_mut(&mut self) -> &mut ValidatorIndex {
+    pub fn state_root(&self) -> Root {
         match self {
-            Self::Bellatrix(inner) => &mut inner.proposer_index,
-            Self::Capella(inner) => &mut inner.proposer_index,
-            Self::Deneb(inner) => &mut inner.proposer_index,
-        }
-    }
-    pub fn parent_root(&self) -> &Root {
-        match self {
-            Self::Bellatrix(inner) => &inner.parent_root,
-            Self::Capella(inner) => &inner.parent_root,
-            Self::Deneb(inner) => &inner.parent_root,
-        }
-    }
-    pub fn parent_root_mut(&mut self) -> &mut Root {
-        match self {
-            Self::Bellatrix(inner) => &mut inner.parent_root,
-            Self::Capella(inner) => &mut inner.parent_root,
-            Self::Deneb(inner) => &mut inner.parent_root,
-        }
-    }
-    pub fn state_root(&self) -> &Root {
-        match self {
-            Self::Bellatrix(inner) => &inner.state_root,
-            Self::Capella(inner) => &inner.state_root,
-            Self::Deneb(inner) => &inner.state_root,
-        }
-    }
-    pub fn state_root_mut(&mut self) -> &mut Root {
-        match self {
-            Self::Bellatrix(inner) => &mut inner.state_root,
-            Self::Capella(inner) => &mut inner.state_root,
-            Self::Deneb(inner) => &mut inner.state_root,
+            Self::Bellatrix(inner) => inner.state_root,
+            Self::Capella(inner) => inner.state_root,
+            Self::Deneb(inner) => inner.state_root,
         }
     }
     pub fn body(

--- a/ethereum-consensus/src/types/execution_payload.rs
+++ b/ethereum-consensus/src/types/execution_payload.rs
@@ -243,60 +243,32 @@ impl<
             Self::Deneb(inner) => &mut inner.prev_randao,
         }
     }
-    pub fn block_number(&self) -> &u64 {
+    pub fn block_number(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &inner.block_number,
-            Self::Capella(inner) => &inner.block_number,
-            Self::Deneb(inner) => &inner.block_number,
+            Self::Bellatrix(inner) => inner.block_number,
+            Self::Capella(inner) => inner.block_number,
+            Self::Deneb(inner) => inner.block_number,
         }
     }
-    pub fn block_number_mut(&mut self) -> &mut u64 {
+    pub fn gas_limit(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &mut inner.block_number,
-            Self::Capella(inner) => &mut inner.block_number,
-            Self::Deneb(inner) => &mut inner.block_number,
+            Self::Bellatrix(inner) => inner.gas_limit,
+            Self::Capella(inner) => inner.gas_limit,
+            Self::Deneb(inner) => inner.gas_limit,
         }
     }
-    pub fn gas_limit(&self) -> &u64 {
+    pub fn gas_used(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &inner.gas_limit,
-            Self::Capella(inner) => &inner.gas_limit,
-            Self::Deneb(inner) => &inner.gas_limit,
+            Self::Bellatrix(inner) => inner.gas_used,
+            Self::Capella(inner) => inner.gas_used,
+            Self::Deneb(inner) => inner.gas_used,
         }
     }
-    pub fn gas_limit_mut(&mut self) -> &mut u64 {
+    pub fn timestamp(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &mut inner.gas_limit,
-            Self::Capella(inner) => &mut inner.gas_limit,
-            Self::Deneb(inner) => &mut inner.gas_limit,
-        }
-    }
-    pub fn gas_used(&self) -> &u64 {
-        match self {
-            Self::Bellatrix(inner) => &inner.gas_used,
-            Self::Capella(inner) => &inner.gas_used,
-            Self::Deneb(inner) => &inner.gas_used,
-        }
-    }
-    pub fn gas_used_mut(&mut self) -> &mut u64 {
-        match self {
-            Self::Bellatrix(inner) => &mut inner.gas_used,
-            Self::Capella(inner) => &mut inner.gas_used,
-            Self::Deneb(inner) => &mut inner.gas_used,
-        }
-    }
-    pub fn timestamp(&self) -> &u64 {
-        match self {
-            Self::Bellatrix(inner) => &inner.timestamp,
-            Self::Capella(inner) => &inner.timestamp,
-            Self::Deneb(inner) => &inner.timestamp,
-        }
-    }
-    pub fn timestamp_mut(&mut self) -> &mut u64 {
-        match self {
-            Self::Bellatrix(inner) => &mut inner.timestamp,
-            Self::Capella(inner) => &mut inner.timestamp,
-            Self::Deneb(inner) => &mut inner.timestamp,
+            Self::Bellatrix(inner) => inner.timestamp,
+            Self::Capella(inner) => inner.timestamp,
+            Self::Deneb(inner) => inner.timestamp,
         }
     }
     pub fn extra_data(&self) -> &ByteList<MAX_EXTRA_DATA_BYTES> {
@@ -375,32 +347,18 @@ impl<
             Self::Deneb(inner) => Some(&mut inner.withdrawals),
         }
     }
-    pub fn blob_gas_used(&self) -> Option<&u64> {
+    pub fn blob_gas_used(&self) -> Option<u64> {
         match self {
             Self::Bellatrix(_) => None,
             Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&inner.blob_gas_used),
+            Self::Deneb(inner) => Some(inner.blob_gas_used),
         }
     }
-    pub fn blob_gas_used_mut(&mut self) -> Option<&mut u64> {
+    pub fn excess_blob_gas(&self) -> Option<u64> {
         match self {
             Self::Bellatrix(_) => None,
             Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&mut inner.blob_gas_used),
-        }
-    }
-    pub fn excess_blob_gas(&self) -> Option<&u64> {
-        match self {
-            Self::Bellatrix(_) => None,
-            Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&inner.excess_blob_gas),
-        }
-    }
-    pub fn excess_blob_gas_mut(&mut self) -> Option<&mut u64> {
-        match self {
-            Self::Bellatrix(_) => None,
-            Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&mut inner.excess_blob_gas),
+            Self::Deneb(inner) => Some(inner.excess_blob_gas),
         }
     }
 }
@@ -586,32 +544,32 @@ impl<
             Self::Deneb(inner) => &inner.prev_randao,
         }
     }
-    pub fn block_number(&self) -> &u64 {
+    pub fn block_number(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &inner.block_number,
-            Self::Capella(inner) => &inner.block_number,
-            Self::Deneb(inner) => &inner.block_number,
+            Self::Bellatrix(inner) => inner.block_number,
+            Self::Capella(inner) => inner.block_number,
+            Self::Deneb(inner) => inner.block_number,
         }
     }
-    pub fn gas_limit(&self) -> &u64 {
+    pub fn gas_limit(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &inner.gas_limit,
-            Self::Capella(inner) => &inner.gas_limit,
-            Self::Deneb(inner) => &inner.gas_limit,
+            Self::Bellatrix(inner) => inner.gas_limit,
+            Self::Capella(inner) => inner.gas_limit,
+            Self::Deneb(inner) => inner.gas_limit,
         }
     }
-    pub fn gas_used(&self) -> &u64 {
+    pub fn gas_used(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &inner.gas_used,
-            Self::Capella(inner) => &inner.gas_used,
-            Self::Deneb(inner) => &inner.gas_used,
+            Self::Bellatrix(inner) => inner.gas_used,
+            Self::Capella(inner) => inner.gas_used,
+            Self::Deneb(inner) => inner.gas_used,
         }
     }
-    pub fn timestamp(&self) -> &u64 {
+    pub fn timestamp(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &inner.timestamp,
-            Self::Capella(inner) => &inner.timestamp,
-            Self::Deneb(inner) => &inner.timestamp,
+            Self::Bellatrix(inner) => inner.timestamp,
+            Self::Capella(inner) => inner.timestamp,
+            Self::Deneb(inner) => inner.timestamp,
         }
     }
     pub fn extra_data(&self) -> &ByteList<MAX_EXTRA_DATA_BYTES> {
@@ -651,18 +609,18 @@ impl<
             Self::Deneb(inner) => Some(&inner.withdrawals),
         }
     }
-    pub fn blob_gas_used(&self) -> Option<&u64> {
+    pub fn blob_gas_used(&self) -> Option<u64> {
         match self {
             Self::Bellatrix(_) => None,
             Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&inner.blob_gas_used),
+            Self::Deneb(inner) => Some(inner.blob_gas_used),
         }
     }
-    pub fn excess_blob_gas(&self) -> Option<&u64> {
+    pub fn excess_blob_gas(&self) -> Option<u64> {
         match self {
             Self::Bellatrix(_) => None,
             Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&inner.excess_blob_gas),
+            Self::Deneb(inner) => Some(inner.excess_blob_gas),
         }
     }
 }
@@ -1017,60 +975,32 @@ impl<
             Self::Deneb(inner) => &mut inner.prev_randao,
         }
     }
-    pub fn block_number(&self) -> &u64 {
+    pub fn block_number(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &inner.block_number,
-            Self::Capella(inner) => &inner.block_number,
-            Self::Deneb(inner) => &inner.block_number,
+            Self::Bellatrix(inner) => inner.block_number,
+            Self::Capella(inner) => inner.block_number,
+            Self::Deneb(inner) => inner.block_number,
         }
     }
-    pub fn block_number_mut(&mut self) -> &mut u64 {
+    pub fn gas_limit(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &mut inner.block_number,
-            Self::Capella(inner) => &mut inner.block_number,
-            Self::Deneb(inner) => &mut inner.block_number,
+            Self::Bellatrix(inner) => inner.gas_limit,
+            Self::Capella(inner) => inner.gas_limit,
+            Self::Deneb(inner) => inner.gas_limit,
         }
     }
-    pub fn gas_limit(&self) -> &u64 {
+    pub fn gas_used(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &inner.gas_limit,
-            Self::Capella(inner) => &inner.gas_limit,
-            Self::Deneb(inner) => &inner.gas_limit,
+            Self::Bellatrix(inner) => inner.gas_used,
+            Self::Capella(inner) => inner.gas_used,
+            Self::Deneb(inner) => inner.gas_used,
         }
     }
-    pub fn gas_limit_mut(&mut self) -> &mut u64 {
+    pub fn timestamp(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &mut inner.gas_limit,
-            Self::Capella(inner) => &mut inner.gas_limit,
-            Self::Deneb(inner) => &mut inner.gas_limit,
-        }
-    }
-    pub fn gas_used(&self) -> &u64 {
-        match self {
-            Self::Bellatrix(inner) => &inner.gas_used,
-            Self::Capella(inner) => &inner.gas_used,
-            Self::Deneb(inner) => &inner.gas_used,
-        }
-    }
-    pub fn gas_used_mut(&mut self) -> &mut u64 {
-        match self {
-            Self::Bellatrix(inner) => &mut inner.gas_used,
-            Self::Capella(inner) => &mut inner.gas_used,
-            Self::Deneb(inner) => &mut inner.gas_used,
-        }
-    }
-    pub fn timestamp(&self) -> &u64 {
-        match self {
-            Self::Bellatrix(inner) => &inner.timestamp,
-            Self::Capella(inner) => &inner.timestamp,
-            Self::Deneb(inner) => &inner.timestamp,
-        }
-    }
-    pub fn timestamp_mut(&mut self) -> &mut u64 {
-        match self {
-            Self::Bellatrix(inner) => &mut inner.timestamp,
-            Self::Capella(inner) => &mut inner.timestamp,
-            Self::Deneb(inner) => &mut inner.timestamp,
+            Self::Bellatrix(inner) => inner.timestamp,
+            Self::Capella(inner) => inner.timestamp,
+            Self::Deneb(inner) => inner.timestamp,
         }
     }
     pub fn extra_data(&self) -> &ByteList<MAX_EXTRA_DATA_BYTES> {
@@ -1149,32 +1079,18 @@ impl<
             Self::Deneb(inner) => Some(&mut inner.withdrawals),
         }
     }
-    pub fn blob_gas_used(&self) -> Option<&u64> {
+    pub fn blob_gas_used(&self) -> Option<u64> {
         match self {
             Self::Bellatrix(_) => None,
             Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&inner.blob_gas_used),
+            Self::Deneb(inner) => Some(inner.blob_gas_used),
         }
     }
-    pub fn blob_gas_used_mut(&mut self) -> Option<&mut u64> {
+    pub fn excess_blob_gas(&self) -> Option<u64> {
         match self {
             Self::Bellatrix(_) => None,
             Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&mut inner.blob_gas_used),
-        }
-    }
-    pub fn excess_blob_gas(&self) -> Option<&u64> {
-        match self {
-            Self::Bellatrix(_) => None,
-            Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&inner.excess_blob_gas),
-        }
-    }
-    pub fn excess_blob_gas_mut(&mut self) -> Option<&mut u64> {
-        match self {
-            Self::Bellatrix(_) => None,
-            Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&mut inner.excess_blob_gas),
+            Self::Deneb(inner) => Some(inner.excess_blob_gas),
         }
     }
 }

--- a/ethereum-consensus/src/types/execution_payload_header.rs
+++ b/ethereum-consensus/src/types/execution_payload_header.rs
@@ -163,60 +163,32 @@ impl<const BYTES_PER_LOGS_BLOOM: usize, const MAX_EXTRA_DATA_BYTES: usize>
             Self::Deneb(inner) => &mut inner.prev_randao,
         }
     }
-    pub fn block_number(&self) -> &u64 {
+    pub fn block_number(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &inner.block_number,
-            Self::Capella(inner) => &inner.block_number,
-            Self::Deneb(inner) => &inner.block_number,
+            Self::Bellatrix(inner) => inner.block_number,
+            Self::Capella(inner) => inner.block_number,
+            Self::Deneb(inner) => inner.block_number,
         }
     }
-    pub fn block_number_mut(&mut self) -> &mut u64 {
+    pub fn gas_limit(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &mut inner.block_number,
-            Self::Capella(inner) => &mut inner.block_number,
-            Self::Deneb(inner) => &mut inner.block_number,
+            Self::Bellatrix(inner) => inner.gas_limit,
+            Self::Capella(inner) => inner.gas_limit,
+            Self::Deneb(inner) => inner.gas_limit,
         }
     }
-    pub fn gas_limit(&self) -> &u64 {
+    pub fn gas_used(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &inner.gas_limit,
-            Self::Capella(inner) => &inner.gas_limit,
-            Self::Deneb(inner) => &inner.gas_limit,
+            Self::Bellatrix(inner) => inner.gas_used,
+            Self::Capella(inner) => inner.gas_used,
+            Self::Deneb(inner) => inner.gas_used,
         }
     }
-    pub fn gas_limit_mut(&mut self) -> &mut u64 {
+    pub fn timestamp(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &mut inner.gas_limit,
-            Self::Capella(inner) => &mut inner.gas_limit,
-            Self::Deneb(inner) => &mut inner.gas_limit,
-        }
-    }
-    pub fn gas_used(&self) -> &u64 {
-        match self {
-            Self::Bellatrix(inner) => &inner.gas_used,
-            Self::Capella(inner) => &inner.gas_used,
-            Self::Deneb(inner) => &inner.gas_used,
-        }
-    }
-    pub fn gas_used_mut(&mut self) -> &mut u64 {
-        match self {
-            Self::Bellatrix(inner) => &mut inner.gas_used,
-            Self::Capella(inner) => &mut inner.gas_used,
-            Self::Deneb(inner) => &mut inner.gas_used,
-        }
-    }
-    pub fn timestamp(&self) -> &u64 {
-        match self {
-            Self::Bellatrix(inner) => &inner.timestamp,
-            Self::Capella(inner) => &inner.timestamp,
-            Self::Deneb(inner) => &inner.timestamp,
-        }
-    }
-    pub fn timestamp_mut(&mut self) -> &mut u64 {
-        match self {
-            Self::Bellatrix(inner) => &mut inner.timestamp,
-            Self::Capella(inner) => &mut inner.timestamp,
-            Self::Deneb(inner) => &mut inner.timestamp,
+            Self::Bellatrix(inner) => inner.timestamp,
+            Self::Capella(inner) => inner.timestamp,
+            Self::Deneb(inner) => inner.timestamp,
         }
     }
     pub fn extra_data(&self) -> &ByteList<MAX_EXTRA_DATA_BYTES> {
@@ -261,60 +233,32 @@ impl<const BYTES_PER_LOGS_BLOOM: usize, const MAX_EXTRA_DATA_BYTES: usize>
             Self::Deneb(inner) => &mut inner.block_hash,
         }
     }
-    pub fn transactions_root(&self) -> &Root {
+    pub fn transactions_root(&self) -> Root {
         match self {
-            Self::Bellatrix(inner) => &inner.transactions_root,
-            Self::Capella(inner) => &inner.transactions_root,
-            Self::Deneb(inner) => &inner.transactions_root,
+            Self::Bellatrix(inner) => inner.transactions_root,
+            Self::Capella(inner) => inner.transactions_root,
+            Self::Deneb(inner) => inner.transactions_root,
         }
     }
-    pub fn transactions_root_mut(&mut self) -> &mut Root {
-        match self {
-            Self::Bellatrix(inner) => &mut inner.transactions_root,
-            Self::Capella(inner) => &mut inner.transactions_root,
-            Self::Deneb(inner) => &mut inner.transactions_root,
-        }
-    }
-    pub fn withdrawals_root(&self) -> Option<&Root> {
+    pub fn withdrawals_root(&self) -> Option<Root> {
         match self {
             Self::Bellatrix(_) => None,
-            Self::Capella(inner) => Some(&inner.withdrawals_root),
-            Self::Deneb(inner) => Some(&inner.withdrawals_root),
+            Self::Capella(inner) => Some(inner.withdrawals_root),
+            Self::Deneb(inner) => Some(inner.withdrawals_root),
         }
     }
-    pub fn withdrawals_root_mut(&mut self) -> Option<&mut Root> {
-        match self {
-            Self::Bellatrix(_) => None,
-            Self::Capella(inner) => Some(&mut inner.withdrawals_root),
-            Self::Deneb(inner) => Some(&mut inner.withdrawals_root),
-        }
-    }
-    pub fn blob_gas_used(&self) -> Option<&u64> {
+    pub fn blob_gas_used(&self) -> Option<u64> {
         match self {
             Self::Bellatrix(_) => None,
             Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&inner.blob_gas_used),
+            Self::Deneb(inner) => Some(inner.blob_gas_used),
         }
     }
-    pub fn blob_gas_used_mut(&mut self) -> Option<&mut u64> {
+    pub fn excess_blob_gas(&self) -> Option<u64> {
         match self {
             Self::Bellatrix(_) => None,
             Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&mut inner.blob_gas_used),
-        }
-    }
-    pub fn excess_blob_gas(&self) -> Option<&u64> {
-        match self {
-            Self::Bellatrix(_) => None,
-            Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&inner.excess_blob_gas),
-        }
-    }
-    pub fn excess_blob_gas_mut(&mut self) -> Option<&mut u64> {
-        match self {
-            Self::Bellatrix(_) => None,
-            Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&mut inner.excess_blob_gas),
+            Self::Deneb(inner) => Some(inner.excess_blob_gas),
         }
     }
 }
@@ -425,32 +369,32 @@ impl<'a, const BYTES_PER_LOGS_BLOOM: usize, const MAX_EXTRA_DATA_BYTES: usize>
             Self::Deneb(inner) => &inner.prev_randao,
         }
     }
-    pub fn block_number(&self) -> &u64 {
+    pub fn block_number(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &inner.block_number,
-            Self::Capella(inner) => &inner.block_number,
-            Self::Deneb(inner) => &inner.block_number,
+            Self::Bellatrix(inner) => inner.block_number,
+            Self::Capella(inner) => inner.block_number,
+            Self::Deneb(inner) => inner.block_number,
         }
     }
-    pub fn gas_limit(&self) -> &u64 {
+    pub fn gas_limit(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &inner.gas_limit,
-            Self::Capella(inner) => &inner.gas_limit,
-            Self::Deneb(inner) => &inner.gas_limit,
+            Self::Bellatrix(inner) => inner.gas_limit,
+            Self::Capella(inner) => inner.gas_limit,
+            Self::Deneb(inner) => inner.gas_limit,
         }
     }
-    pub fn gas_used(&self) -> &u64 {
+    pub fn gas_used(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &inner.gas_used,
-            Self::Capella(inner) => &inner.gas_used,
-            Self::Deneb(inner) => &inner.gas_used,
+            Self::Bellatrix(inner) => inner.gas_used,
+            Self::Capella(inner) => inner.gas_used,
+            Self::Deneb(inner) => inner.gas_used,
         }
     }
-    pub fn timestamp(&self) -> &u64 {
+    pub fn timestamp(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &inner.timestamp,
-            Self::Capella(inner) => &inner.timestamp,
-            Self::Deneb(inner) => &inner.timestamp,
+            Self::Bellatrix(inner) => inner.timestamp,
+            Self::Capella(inner) => inner.timestamp,
+            Self::Deneb(inner) => inner.timestamp,
         }
     }
     pub fn extra_data(&self) -> &ByteList<MAX_EXTRA_DATA_BYTES> {
@@ -474,32 +418,32 @@ impl<'a, const BYTES_PER_LOGS_BLOOM: usize, const MAX_EXTRA_DATA_BYTES: usize>
             Self::Deneb(inner) => &inner.block_hash,
         }
     }
-    pub fn transactions_root(&self) -> &Root {
+    pub fn transactions_root(&self) -> Root {
         match self {
-            Self::Bellatrix(inner) => &inner.transactions_root,
-            Self::Capella(inner) => &inner.transactions_root,
-            Self::Deneb(inner) => &inner.transactions_root,
+            Self::Bellatrix(inner) => inner.transactions_root,
+            Self::Capella(inner) => inner.transactions_root,
+            Self::Deneb(inner) => inner.transactions_root,
         }
     }
-    pub fn withdrawals_root(&self) -> Option<&Root> {
-        match self {
-            Self::Bellatrix(_) => None,
-            Self::Capella(inner) => Some(&inner.withdrawals_root),
-            Self::Deneb(inner) => Some(&inner.withdrawals_root),
-        }
-    }
-    pub fn blob_gas_used(&self) -> Option<&u64> {
+    pub fn withdrawals_root(&self) -> Option<Root> {
         match self {
             Self::Bellatrix(_) => None,
-            Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&inner.blob_gas_used),
+            Self::Capella(inner) => Some(inner.withdrawals_root),
+            Self::Deneb(inner) => Some(inner.withdrawals_root),
         }
     }
-    pub fn excess_blob_gas(&self) -> Option<&u64> {
+    pub fn blob_gas_used(&self) -> Option<u64> {
         match self {
             Self::Bellatrix(_) => None,
             Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&inner.excess_blob_gas),
+            Self::Deneb(inner) => Some(inner.blob_gas_used),
+        }
+    }
+    pub fn excess_blob_gas(&self) -> Option<u64> {
+        match self {
+            Self::Bellatrix(_) => None,
+            Self::Capella(_) => None,
+            Self::Deneb(inner) => Some(inner.excess_blob_gas),
         }
     }
 }
@@ -692,60 +636,32 @@ impl<'a, const BYTES_PER_LOGS_BLOOM: usize, const MAX_EXTRA_DATA_BYTES: usize>
             Self::Deneb(inner) => &mut inner.prev_randao,
         }
     }
-    pub fn block_number(&self) -> &u64 {
+    pub fn block_number(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &inner.block_number,
-            Self::Capella(inner) => &inner.block_number,
-            Self::Deneb(inner) => &inner.block_number,
+            Self::Bellatrix(inner) => inner.block_number,
+            Self::Capella(inner) => inner.block_number,
+            Self::Deneb(inner) => inner.block_number,
         }
     }
-    pub fn block_number_mut(&mut self) -> &mut u64 {
+    pub fn gas_limit(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &mut inner.block_number,
-            Self::Capella(inner) => &mut inner.block_number,
-            Self::Deneb(inner) => &mut inner.block_number,
+            Self::Bellatrix(inner) => inner.gas_limit,
+            Self::Capella(inner) => inner.gas_limit,
+            Self::Deneb(inner) => inner.gas_limit,
         }
     }
-    pub fn gas_limit(&self) -> &u64 {
+    pub fn gas_used(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &inner.gas_limit,
-            Self::Capella(inner) => &inner.gas_limit,
-            Self::Deneb(inner) => &inner.gas_limit,
+            Self::Bellatrix(inner) => inner.gas_used,
+            Self::Capella(inner) => inner.gas_used,
+            Self::Deneb(inner) => inner.gas_used,
         }
     }
-    pub fn gas_limit_mut(&mut self) -> &mut u64 {
+    pub fn timestamp(&self) -> u64 {
         match self {
-            Self::Bellatrix(inner) => &mut inner.gas_limit,
-            Self::Capella(inner) => &mut inner.gas_limit,
-            Self::Deneb(inner) => &mut inner.gas_limit,
-        }
-    }
-    pub fn gas_used(&self) -> &u64 {
-        match self {
-            Self::Bellatrix(inner) => &inner.gas_used,
-            Self::Capella(inner) => &inner.gas_used,
-            Self::Deneb(inner) => &inner.gas_used,
-        }
-    }
-    pub fn gas_used_mut(&mut self) -> &mut u64 {
-        match self {
-            Self::Bellatrix(inner) => &mut inner.gas_used,
-            Self::Capella(inner) => &mut inner.gas_used,
-            Self::Deneb(inner) => &mut inner.gas_used,
-        }
-    }
-    pub fn timestamp(&self) -> &u64 {
-        match self {
-            Self::Bellatrix(inner) => &inner.timestamp,
-            Self::Capella(inner) => &inner.timestamp,
-            Self::Deneb(inner) => &inner.timestamp,
-        }
-    }
-    pub fn timestamp_mut(&mut self) -> &mut u64 {
-        match self {
-            Self::Bellatrix(inner) => &mut inner.timestamp,
-            Self::Capella(inner) => &mut inner.timestamp,
-            Self::Deneb(inner) => &mut inner.timestamp,
+            Self::Bellatrix(inner) => inner.timestamp,
+            Self::Capella(inner) => inner.timestamp,
+            Self::Deneb(inner) => inner.timestamp,
         }
     }
     pub fn extra_data(&self) -> &ByteList<MAX_EXTRA_DATA_BYTES> {
@@ -790,60 +706,32 @@ impl<'a, const BYTES_PER_LOGS_BLOOM: usize, const MAX_EXTRA_DATA_BYTES: usize>
             Self::Deneb(inner) => &mut inner.block_hash,
         }
     }
-    pub fn transactions_root(&self) -> &Root {
+    pub fn transactions_root(&self) -> Root {
         match self {
-            Self::Bellatrix(inner) => &inner.transactions_root,
-            Self::Capella(inner) => &inner.transactions_root,
-            Self::Deneb(inner) => &inner.transactions_root,
+            Self::Bellatrix(inner) => inner.transactions_root,
+            Self::Capella(inner) => inner.transactions_root,
+            Self::Deneb(inner) => inner.transactions_root,
         }
     }
-    pub fn transactions_root_mut(&mut self) -> &mut Root {
-        match self {
-            Self::Bellatrix(inner) => &mut inner.transactions_root,
-            Self::Capella(inner) => &mut inner.transactions_root,
-            Self::Deneb(inner) => &mut inner.transactions_root,
-        }
-    }
-    pub fn withdrawals_root(&self) -> Option<&Root> {
+    pub fn withdrawals_root(&self) -> Option<Root> {
         match self {
             Self::Bellatrix(_) => None,
-            Self::Capella(inner) => Some(&inner.withdrawals_root),
-            Self::Deneb(inner) => Some(&inner.withdrawals_root),
+            Self::Capella(inner) => Some(inner.withdrawals_root),
+            Self::Deneb(inner) => Some(inner.withdrawals_root),
         }
     }
-    pub fn withdrawals_root_mut(&mut self) -> Option<&mut Root> {
-        match self {
-            Self::Bellatrix(_) => None,
-            Self::Capella(inner) => Some(&mut inner.withdrawals_root),
-            Self::Deneb(inner) => Some(&mut inner.withdrawals_root),
-        }
-    }
-    pub fn blob_gas_used(&self) -> Option<&u64> {
+    pub fn blob_gas_used(&self) -> Option<u64> {
         match self {
             Self::Bellatrix(_) => None,
             Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&inner.blob_gas_used),
+            Self::Deneb(inner) => Some(inner.blob_gas_used),
         }
     }
-    pub fn blob_gas_used_mut(&mut self) -> Option<&mut u64> {
+    pub fn excess_blob_gas(&self) -> Option<u64> {
         match self {
             Self::Bellatrix(_) => None,
             Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&mut inner.blob_gas_used),
-        }
-    }
-    pub fn excess_blob_gas(&self) -> Option<&u64> {
-        match self {
-            Self::Bellatrix(_) => None,
-            Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&inner.excess_blob_gas),
-        }
-    }
-    pub fn excess_blob_gas_mut(&mut self) -> Option<&mut u64> {
-        match self {
-            Self::Bellatrix(_) => None,
-            Self::Capella(_) => None,
-            Self::Deneb(inner) => Some(&mut inner.excess_blob_gas),
+            Self::Deneb(inner) => Some(inner.excess_blob_gas),
         }
     }
 }

--- a/spec-gen/src/visitors.rs
+++ b/spec-gen/src/visitors.rs
@@ -167,6 +167,12 @@ impl TypeNameVisitor {
     pub fn analyze(&mut self, f: &ItemFn) {
         self.visit_item_fn(f)
     }
+
+    pub fn analyze_type(&mut self, t: &Type) {
+        self.in_context = true;
+        self.visit_type(t);
+        self.in_context = false;
+    }
 }
 
 impl<'ast> Visit<'ast> for TypeNameVisitor {


### PR DESCRIPTION
before, any generated accessor would always return a ref, even when the type is copy

now, we just return a copy to simplify the accessor set