### PR TITLE
ensure `beacon-api-client` "type group" is Clone

### DIFF
--- a/beacon-api-client/src/api_client.rs
+++ b/beacon-api-client/src/api_client.rs
@@ -51,7 +51,7 @@ async fn api_error_or_value<T: serde::de::DeserializeOwned>(
     }
 }
 
-pub trait ClientTypes {
+pub trait ClientTypes: Clone {
     type SignedContributionAndProof: serde::Serialize;
     type SyncCommitteeContribution: serde::Serialize + serde::de::DeserializeOwned;
     type BlindedBeaconBlock: serde::Serialize + serde::de::DeserializeOwned;

--- a/beacon-api-client/src/lib.rs
+++ b/beacon-api-client/src/lib.rs
@@ -43,6 +43,7 @@ pub mod presets {
             },
         };
 
+        #[derive(Clone)]
         pub struct MainnetClientTypes;
 
         impl crate::ClientTypes for MainnetClientTypes {
@@ -76,6 +77,7 @@ pub mod presets {
             },
         };
 
+        #[derive(Clone)]
         pub struct MinimalClientTypes;
 
         impl crate::ClientTypes for MinimalClientTypes {


### PR DESCRIPTION
in order to `Clone` the client, the inner type `C` declared in #287 must also be `Clone`