### PR TITLE
missing `transparent` attr on generated types

### DIFF
--- a/ethereum-consensus/src/types/beacon_block.rs
+++ b/ethereum-consensus/src/types/beacon_block.rs
@@ -11,6 +11,7 @@ use crate::{
     Fork as Version,
 };
 #[derive(Debug, Clone, PartialEq, Eq, Merkleized, serde::Serialize)]
+#[ssz(transparent)]
 #[serde(untagged)]
 pub enum BeaconBlock<
     const MAX_PROPOSER_SLASHINGS: usize,

--- a/ethereum-consensus/src/types/beacon_block_body.rs
+++ b/ethereum-consensus/src/types/beacon_block_body.rs
@@ -14,6 +14,7 @@ use crate::{
     Fork as Version,
 };
 #[derive(Debug, Clone, PartialEq, Eq, Merkleized, serde::Serialize)]
+#[ssz(transparent)]
 #[serde(untagged)]
 pub enum BeaconBlockBody<
     const MAX_PROPOSER_SLASHINGS: usize,

--- a/ethereum-consensus/src/types/beacon_state.rs
+++ b/ethereum-consensus/src/types/beacon_state.rs
@@ -17,6 +17,7 @@ use crate::{
     Fork as Version,
 };
 #[derive(Debug, Clone, PartialEq, Eq, Merkleized, serde::Serialize)]
+#[ssz(transparent)]
 #[serde(untagged)]
 pub enum BeaconState<
     const SLOTS_PER_HISTORICAL_ROOT: usize,

--- a/ethereum-consensus/src/types/blinded_beacon_block.rs
+++ b/ethereum-consensus/src/types/blinded_beacon_block.rs
@@ -9,6 +9,7 @@ use crate::{
     Fork as Version,
 };
 #[derive(Debug, Clone, PartialEq, Eq, Merkleized, serde::Serialize)]
+#[ssz(transparent)]
 #[serde(untagged)]
 pub enum BlindedBeaconBlock<
     const MAX_PROPOSER_SLASHINGS: usize,

--- a/ethereum-consensus/src/types/blinded_beacon_block_body.rs
+++ b/ethereum-consensus/src/types/blinded_beacon_block_body.rs
@@ -13,6 +13,7 @@ use crate::{
     Fork as Version,
 };
 #[derive(Debug, Clone, PartialEq, Eq, Merkleized, serde::Serialize)]
+#[ssz(transparent)]
 #[serde(untagged)]
 pub enum BlindedBeaconBlockBody<
     const MAX_PROPOSER_SLASHINGS: usize,

--- a/ethereum-consensus/src/types/execution_payload.rs
+++ b/ethereum-consensus/src/types/execution_payload.rs
@@ -8,6 +8,7 @@ use crate::{
     Fork as Version,
 };
 #[derive(Debug, Clone, PartialEq, Eq, Merkleized, serde::Serialize)]
+#[ssz(transparent)]
 #[serde(untagged)]
 pub enum ExecutionPayload<
     const BYTES_PER_LOGS_BLOOM: usize,

--- a/ethereum-consensus/src/types/execution_payload_header.rs
+++ b/ethereum-consensus/src/types/execution_payload_header.rs
@@ -8,6 +8,7 @@ use crate::{
     Fork as Version,
 };
 #[derive(Debug, Clone, PartialEq, Eq, Merkleized, serde::Serialize)]
+#[ssz(transparent)]
 #[serde(untagged)]
 pub enum ExecutionPayloadHeader<
     const BYTES_PER_LOGS_BLOOM: usize,

--- a/ethereum-consensus/src/types/signed_beacon_block.rs
+++ b/ethereum-consensus/src/types/signed_beacon_block.rs
@@ -11,6 +11,7 @@ use crate::{
     Fork as Version,
 };
 #[derive(Debug, Clone, PartialEq, Eq, Merkleized, serde::Serialize)]
+#[ssz(transparent)]
 #[serde(untagged)]
 pub enum SignedBeaconBlock<
     const MAX_PROPOSER_SLASHINGS: usize,

--- a/ethereum-consensus/src/types/signed_blinded_beacon_block.rs
+++ b/ethereum-consensus/src/types/signed_blinded_beacon_block.rs
@@ -9,6 +9,7 @@ use crate::{
     Fork as Version,
 };
 #[derive(Debug, Clone, PartialEq, Eq, Merkleized, serde::Serialize)]
+#[ssz(transparent)]
 #[serde(untagged)]
 pub enum SignedBlindedBeaconBlock<
     const MAX_PROPOSER_SLASHINGS: usize,

--- a/spec-gen/src/type_generator.rs
+++ b/spec-gen/src/type_generator.rs
@@ -371,6 +371,7 @@ fn derive_type_defn(target_type: &Type, merge_type: &MergeType) -> (Item, Generi
         .collect::<Vec<syn::Variant>>();
     let enum_defn = parse_quote! {
         #[derive(Debug, Clone, PartialEq, Eq, Merkleized, serde::Serialize)]
+        #[ssz(transparent)]
         #[serde(untagged)]
         pub enum #type_name #generics {
             #(#variant_defns),*


### PR DESCRIPTION
this caused hash tree root calculations to be incorrect, e.g. when verifying bids in https://github.com/ralexstokes/mev-rs