### PR TITLE
Update blob_sidecar type

### DIFF
--- a/ethereum-consensus/src/deneb/blob_sidecar.rs
+++ b/ethereum-consensus/src/deneb/blob_sidecar.rs
@@ -3,7 +3,7 @@ use crate::{
         polynomial_commitments::{KzgCommitment, KzgProof},
         SignedBeaconBlockHeader,
     },
-    primitives::{BlobIndex, BlsSignature, Bytes32, Root, Slot, ValidatorIndex},
+    primitives::{BlobIndex, BlsSignature, Bytes32, Root},
     ssz::prelude::*,
 };
 
@@ -15,21 +15,27 @@ pub type Blob<const BYTES_PER_BLOB: usize> = ByteVector<BYTES_PER_BLOB>;
 #[derive(
     Default, Debug, Clone, SimpleSerialize, PartialEq, Eq, serde::Serialize, serde::Deserialize,
 )]
-pub struct BlobSidecar<const BYTES_PER_BLOB: usize> {
+pub struct BlobSidecar<
+    const BYTES_PER_BLOB: usize,
+    const KZG_COMMITMENT_INCLUSION_PROOF_DEPTH: usize,
+> {
     #[serde(with = "crate::serde::as_str")]
     pub index: BlobIndex,
     pub blob: Blob<BYTES_PER_BLOB>,
     pub kzg_commitment: KzgCommitment,
     pub kzg_proof: KzgProof,
     pub signed_block_header: SignedBeaconBlockHeader,
-    pub kzg_commitment_inclusion_proof: Vec<Bytes32>,
+    pub kzg_commitment_inclusion_proof: Vector<Bytes32, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH>,
 }
 
 #[derive(
     Default, Debug, Clone, SimpleSerialize, PartialEq, Eq, serde::Serialize, serde::Deserialize,
 )]
-pub struct SignedBlobSidecar<const BYTES_PER_BLOB: usize> {
-    pub message: BlobSidecar<BYTES_PER_BLOB>,
+pub struct SignedBlobSidecar<
+    const BYTES_PER_BLOB: usize,
+    const KZG_COMMITMENT_INCLUSION_PROOF_DEPTH: usize,
+> {
+    pub message: BlobSidecar<BYTES_PER_BLOB, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH>,
     pub signature: BlsSignature,
 }
 

--- a/ethereum-consensus/src/deneb/blob_sidecar.rs
+++ b/ethereum-consensus/src/deneb/blob_sidecar.rs
@@ -3,7 +3,7 @@ use crate::{
         polynomial_commitments::{KzgCommitment, KzgProof},
         SignedBeaconBlockHeader,
     },
-    primitives::{BlobIndex, BlsSignature, Bytes32, Root},
+    primitives::{BlobIndex, Bytes32, Root},
     ssz::prelude::*,
 };
 

--- a/ethereum-consensus/src/deneb/blob_sidecar.rs
+++ b/ethereum-consensus/src/deneb/blob_sidecar.rs
@@ -1,6 +1,9 @@
 use crate::{
-    deneb::polynomial_commitments::{KzgCommitment, KzgProof},
-    primitives::{BlobIndex, BlsSignature, Root, Slot, ValidatorIndex},
+    deneb::{
+        polynomial_commitments::{KzgCommitment, KzgProof},
+        SignedBeaconBlockHeader,
+    },
+    primitives::{BlobIndex, BlsSignature, Bytes32, Root, Slot, ValidatorIndex},
     ssz::prelude::*,
 };
 
@@ -13,17 +16,13 @@ pub type Blob<const BYTES_PER_BLOB: usize> = ByteVector<BYTES_PER_BLOB>;
     Default, Debug, Clone, SimpleSerialize, PartialEq, Eq, serde::Serialize, serde::Deserialize,
 )]
 pub struct BlobSidecar<const BYTES_PER_BLOB: usize> {
-    pub block_root: Root,
     #[serde(with = "crate::serde::as_str")]
     pub index: BlobIndex,
-    #[serde(with = "crate::serde::as_str")]
-    pub slot: Slot,
-    pub block_parent_root: Root,
-    #[serde(with = "crate::serde::as_str")]
-    pub proposer_index: ValidatorIndex,
     pub blob: Blob<BYTES_PER_BLOB>,
     pub kzg_commitment: KzgCommitment,
     pub kzg_proof: KzgProof,
+    pub signed_block_header: SignedBeaconBlockHeader,
+    pub kzg_commitment_inclusion_proof: Vec<Bytes32>,
 }
 
 #[derive(

--- a/ethereum-consensus/src/deneb/blob_sidecar.rs
+++ b/ethereum-consensus/src/deneb/blob_sidecar.rs
@@ -31,17 +31,6 @@ pub struct BlobSidecar<
 #[derive(
     Default, Debug, Clone, SimpleSerialize, PartialEq, Eq, serde::Serialize, serde::Deserialize,
 )]
-pub struct SignedBlobSidecar<
-    const BYTES_PER_BLOB: usize,
-    const KZG_COMMITMENT_INCLUSION_PROOF_DEPTH: usize,
-> {
-    pub message: BlobSidecar<BYTES_PER_BLOB, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH>,
-    pub signature: BlsSignature,
-}
-
-#[derive(
-    Default, Debug, Clone, SimpleSerialize, PartialEq, Eq, serde::Serialize, serde::Deserialize,
-)]
 pub struct BlobIdentifier {
     pub block_root: Root,
     #[serde(with = "crate::serde::as_str")]

--- a/ethereum-consensus/src/deneb/presets/mainnet.rs
+++ b/ethereum-consensus/src/deneb/presets/mainnet.rs
@@ -151,5 +151,3 @@ pub type SignedBeaconBlock = spec::SignedBeaconBlock<
 
 pub type Blob = spec::Blob<BYTES_PER_BLOB>;
 pub type BlobSidecar = spec::BlobSidecar<BYTES_PER_BLOB, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH>;
-pub type SignedBlobSidecar =
-    spec::SignedBlobSidecar<BYTES_PER_BLOB, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH>;

--- a/ethereum-consensus/src/deneb/presets/mainnet.rs
+++ b/ethereum-consensus/src/deneb/presets/mainnet.rs
@@ -19,6 +19,7 @@ pub use spec::*;
 pub const FIELD_ELEMENTS_PER_BLOB: usize = 4096;
 pub const MAX_BLOB_COMMITMENTS_PER_BLOCK: usize = 4096;
 pub const MAX_BLOBS_PER_BLOCK: usize = 6;
+pub const KZG_COMMITMENT_INCLUSION_PROOF_DEPTH: usize = 17;
 
 pub const BYTES_PER_BLOB: usize =
     crate::deneb::polynomial_commitments::BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB;
@@ -149,5 +150,6 @@ pub type SignedBeaconBlock = spec::SignedBeaconBlock<
 >;
 
 pub type Blob = spec::Blob<BYTES_PER_BLOB>;
-pub type BlobSidecar = spec::BlobSidecar<BYTES_PER_BLOB>;
-pub type SignedBlobSidecar = spec::SignedBlobSidecar<BYTES_PER_BLOB>;
+pub type BlobSidecar = spec::BlobSidecar<BYTES_PER_BLOB, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH>;
+pub type SignedBlobSidecar =
+    spec::SignedBlobSidecar<BYTES_PER_BLOB, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH>;

--- a/ethereum-consensus/src/deneb/presets/minimal.rs
+++ b/ethereum-consensus/src/deneb/presets/minimal.rs
@@ -19,6 +19,7 @@ pub use spec::*;
 pub const FIELD_ELEMENTS_PER_BLOB: usize = 4096;
 pub const MAX_BLOB_COMMITMENTS_PER_BLOCK: usize = 16;
 pub const MAX_BLOBS_PER_BLOCK: usize = 6;
+pub const KZG_COMMITMENT_INCLUSION_PROOF_DEPTH: usize = 9;
 
 pub const BYTES_PER_BLOB: usize =
     crate::deneb::polynomial_commitments::BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB;
@@ -149,5 +150,6 @@ pub type SignedBeaconBlock = spec::SignedBeaconBlock<
 >;
 
 pub type Blob = spec::Blob<BYTES_PER_BLOB>;
-pub type BlobSidecar = spec::BlobSidecar<BYTES_PER_BLOB>;
-pub type SignedBlobSidecar = spec::SignedBlobSidecar<BYTES_PER_BLOB>;
+pub type BlobSidecar = spec::BlobSidecar<BYTES_PER_BLOB, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH>;
+pub type SignedBlobSidecar =
+    spec::SignedBlobSidecar<BYTES_PER_BLOB, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH>;

--- a/ethereum-consensus/src/deneb/presets/minimal.rs
+++ b/ethereum-consensus/src/deneb/presets/minimal.rs
@@ -151,5 +151,3 @@ pub type SignedBeaconBlock = spec::SignedBeaconBlock<
 
 pub type Blob = spec::Blob<BYTES_PER_BLOB>;
 pub type BlobSidecar = spec::BlobSidecar<BYTES_PER_BLOB, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH>;
-pub type SignedBlobSidecar =
-    spec::SignedBlobSidecar<BYTES_PER_BLOB, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH>;

--- a/ethereum-consensus/src/deneb/spec/mod.rs
+++ b/ethereum-consensus/src/deneb/spec/mod.rs
@@ -110,14 +110,14 @@ pub fn process_bls_to_execution_change<
     if address_change.validator_index >= state.validators.len() {
         return Err(invalid_operation_error(InvalidOperation::BlsToExecutionChange(
             InvalidBlsToExecutionChange::ValidatorIndexOutOfBounds(address_change.validator_index),
-        )));
+        )))
     }
     let withdrawal_credentials =
         &mut state.validators[address_change.validator_index].withdrawal_credentials;
     if withdrawal_credentials[0] != BLS_WITHDRAWAL_PREFIX {
         return Err(invalid_operation_error(InvalidOperation::BlsToExecutionChange(
             InvalidBlsToExecutionChange::WithdrawalCredentialsPrefix(withdrawal_credentials[0]),
-        )));
+        )))
     }
     let domain = compute_domain(
         DomainType::BlsToExecutionChange,
@@ -130,7 +130,7 @@ pub fn process_bls_to_execution_change<
     if withdrawal_credentials[1..] != hash(public_key.as_ref())[1..] {
         return Err(invalid_operation_error(InvalidOperation::BlsToExecutionChange(
             InvalidBlsToExecutionChange::PublicKeyMismatch(public_key.clone()),
-        )));
+        )))
     }
     verify_signature(public_key, signing_root.as_ref(), signature)?;
     withdrawal_credentials[0] = ETH1_ADDRESS_WITHDRAWAL_PREFIX;
@@ -200,7 +200,7 @@ pub fn process_operations<
                 expected: expected_deposit_count,
                 count: body.deposits.len(),
             },
-        )));
+        )))
     }
     body.proposer_slashings
         .iter_mut()
@@ -261,7 +261,7 @@ pub fn process_withdrawals<
                 provided: execution_payload.withdrawals.to_vec(),
                 expected: expected_withdrawals,
             },
-        )));
+        )))
     }
     for withdrawal in &expected_withdrawals {
         decrease_balance(state, withdrawal.validator_index, withdrawal.amount);
@@ -338,7 +338,7 @@ pub fn get_expected_withdrawals<
             withdrawal_index += 1;
         }
         if withdrawals.len() == context.max_withdrawals_per_payload {
-            break;
+            break
         }
         validator_index = (validator_index + 1) % state.validators.len();
     }
@@ -383,7 +383,7 @@ pub fn process_deposit<
     if !is_valid_merkle_branch(&leaf, branch.iter(), depth, index, root) {
         return Err(invalid_operation_error(InvalidOperation::Deposit(
             InvalidDeposit::InvalidProof { leaf, branch, depth, index, root: *root },
-        )));
+        )))
     }
     state.eth1_deposit_index += 1;
     let public_key = &deposit.data.public_key;
@@ -399,7 +399,7 @@ pub fn process_deposit<
         let domain = compute_domain(DomainType::Deposit, None, None, context)?;
         let signing_root = compute_signing_root(&mut deposit_message, domain)?;
         if verify_signature(public_key, signing_root.as_ref(), &deposit.data.signature).is_err() {
-            return Ok(());
+            return Ok(())
         }
         state.validators.push(get_validator_from_deposit(deposit, context));
         state.balances.push(amount);
@@ -465,7 +465,7 @@ pub fn process_sync_aggregate<
                 signature: sync_aggregate.sync_committee_signature.clone(),
                 root: signing_root,
             },
-        )));
+        )))
     }
     let total_active_increments =
         get_total_active_balance(state, context)? / context.effective_balance_increment;
@@ -531,7 +531,7 @@ pub fn process_proposer_slashing<
     if header_1.slot != header_2.slot {
         return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
             InvalidProposerSlashing::SlotMismatch(header_1.slot, header_2.slot),
-        )));
+        )))
     }
     if header_1.proposer_index != header_2.proposer_index {
         return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
@@ -539,12 +539,12 @@ pub fn process_proposer_slashing<
                 header_1.proposer_index,
                 header_2.proposer_index,
             ),
-        )));
+        )))
     }
     if header_1 == header_2 {
         return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
             InvalidProposerSlashing::HeadersAreEqual(header_1.clone()),
-        )));
+        )))
     }
     let proposer_index = header_1.proposer_index;
     let proposer = state.validators.get(proposer_index).ok_or_else(|| {
@@ -555,7 +555,7 @@ pub fn process_proposer_slashing<
     if !is_slashable_validator(proposer, get_current_epoch(state, context)) {
         return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
             InvalidProposerSlashing::ProposerIsNotSlashable(header_1.proposer_index),
-        )));
+        )))
     }
     let epoch = compute_epoch_at_slot(header_1.slot, context);
     let domain = get_domain(state, DomainType::BeaconProposer, Some(epoch), context)?;
@@ -567,7 +567,7 @@ pub fn process_proposer_slashing<
         if verify_signature(public_key, signing_root.as_ref(), &signed_header.signature).is_err() {
             return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
                 InvalidProposerSlashing::InvalidSignature(signed_header.signature.clone()),
-            )));
+            )))
         }
     }
     slash_validator(state, proposer_index, None, context)
@@ -607,7 +607,7 @@ pub fn process_attester_slashing<
                 Box::new(attestation_1.data.clone()),
                 Box::new(attestation_2.data.clone()),
             ),
-        )));
+        )))
     }
     is_valid_indexed_attestation(state, attestation_1, context)?;
     is_valid_indexed_attestation(state, attestation_2, context)?;
@@ -705,27 +705,27 @@ pub fn process_block_header<
         return Err(invalid_header_error(InvalidBeaconBlockHeader::StateSlotMismatch {
             state_slot: state.slot,
             block_slot: block.slot,
-        }));
+        }))
     }
     if block.slot <= state.latest_block_header.slot {
         return Err(invalid_header_error(InvalidBeaconBlockHeader::OlderThanLatestBlockHeader {
             block_slot: block.slot,
             latest_block_header_slot: state.latest_block_header.slot,
-        }));
+        }))
     }
     let proposer_index = get_beacon_proposer_index(state, context)?;
     if block.proposer_index != proposer_index {
         return Err(invalid_header_error(InvalidBeaconBlockHeader::ProposerIndexMismatch {
             block_proposer_index: block.proposer_index,
             proposer_index,
-        }));
+        }))
     }
     let expected_parent_root = state.latest_block_header.hash_tree_root()?;
     if block.parent_root != expected_parent_root {
         return Err(invalid_header_error(InvalidBeaconBlockHeader::ParentBlockRootMismatch {
             expected: expected_parent_root,
             provided: block.parent_root,
-        }));
+        }))
     }
     state.latest_block_header = BeaconBlockHeader {
         slot: block.slot,
@@ -736,7 +736,7 @@ pub fn process_block_header<
     };
     let proposer = &state.validators[block.proposer_index];
     if proposer.slashed {
-        return Err(invalid_header_error(InvalidBeaconBlockHeader::ProposerSlashed(proposer_index)));
+        return Err(invalid_header_error(InvalidBeaconBlockHeader::ProposerSlashed(proposer_index)))
     }
     Ok(())
 }
@@ -802,7 +802,7 @@ pub fn process_randao<
     let domain = get_domain(state, DomainType::Randao, Some(epoch), context)?;
     let signing_root = compute_signing_root(&mut epoch, domain)?;
     if verify_signature(&proposer.public_key, signing_root.as_ref(), &body.randao_reveal).is_err() {
-        return Err(invalid_operation_error(InvalidOperation::Randao(body.randao_reveal.clone())));
+        return Err(invalid_operation_error(InvalidOperation::Randao(body.randao_reveal.clone())))
     }
     let mix = xor(get_randao_mix(state, epoch), &hash(body.randao_reveal.as_ref()));
     let mix_index = epoch % context.epochs_per_historical_vector;
@@ -978,8 +978,8 @@ pub fn process_slashings<
     );
     for i in 0..state.validators.len() {
         let validator = &state.validators[i];
-        if validator.slashed
-            && (epoch + context.epochs_per_slashings_vector / 2) == validator.withdrawable_epoch
+        if validator.slashed &&
+            (epoch + context.epochs_per_slashings_vector / 2) == validator.withdrawable_epoch
         {
             let increment = context.effective_balance_increment;
             let penalty_numerator =
@@ -1049,7 +1049,7 @@ pub fn process_justification_and_finalization<
 ) -> Result<()> {
     let current_epoch = get_current_epoch(state, context);
     if current_epoch <= GENESIS_EPOCH + 1 {
-        return Ok(());
+        return Ok(())
     }
     let previous_indices = get_unslashed_participating_indices(
         state,
@@ -1102,7 +1102,7 @@ pub fn process_inactivity_updates<
 ) -> Result<()> {
     let current_epoch = get_current_epoch(state, context);
     if current_epoch == GENESIS_EPOCH {
-        return Ok(());
+        return Ok(())
     }
     let eligible_validator_indices =
         get_eligible_validator_indices(state, context).collect::<Vec<_>>();
@@ -1154,7 +1154,7 @@ pub fn process_rewards_and_penalties<
 ) -> Result<()> {
     let current_epoch = get_current_epoch(state, context);
     if current_epoch == GENESIS_EPOCH {
-        return Ok(());
+        return Ok(())
     }
     let mut deltas = Vec::new();
     for flag_index in 0..PARTICIPATION_FLAG_WEIGHTS.len() {
@@ -1300,8 +1300,8 @@ pub fn process_effective_balance_updates<
     for i in 0..state.validators.len() {
         let validator = &mut state.validators[i];
         let balance = state.balances[i];
-        if balance + downward_threshold < validator.effective_balance
-            || validator.effective_balance + upward_threshold < balance
+        if balance + downward_threshold < validator.effective_balance ||
+            validator.effective_balance + upward_threshold < balance
         {
             validator.effective_balance = Gwei::min(
                 balance - balance % context.effective_balance_increment,
@@ -1585,10 +1585,10 @@ pub fn is_valid_genesis_state<
     context: &Context,
 ) -> bool {
     if state.genesis_time < context.min_genesis_time {
-        return false;
+        return false
     }
-    get_active_validator_indices(state, GENESIS_EPOCH).len()
-        >= context.min_genesis_active_validator_count
+    get_active_validator_indices(state, GENESIS_EPOCH).len() >=
+        context.min_genesis_active_validator_count
 }
 pub fn get_genesis_block<
     const SLOTS_PER_HISTORICAL_ROOT: usize,
@@ -1648,9 +1648,9 @@ pub fn has_eth1_withdrawal_credential(validator: &Validator) -> bool {
     validator.withdrawal_credentials[0] == ETH1_ADDRESS_WITHDRAWAL_PREFIX
 }
 pub fn is_fully_withdrawable_validator(validator: &Validator, balance: Gwei, epoch: Epoch) -> bool {
-    has_eth1_withdrawal_credential(validator)
-        && validator.withdrawable_epoch <= epoch
-        && balance > 0
+    has_eth1_withdrawal_credential(validator) &&
+        validator.withdrawable_epoch <= epoch &&
+        balance > 0
 }
 pub fn is_partially_withdrawable_validator(
     validator: &Validator,
@@ -1748,8 +1748,8 @@ pub fn slash_validator<
     decrease_balance(
         state,
         slashed_index,
-        state.validators[slashed_index].effective_balance
-            / context.min_slashing_penalty_quotient_bellatrix,
+        state.validators[slashed_index].effective_balance /
+            context.min_slashing_penalty_quotient_bellatrix,
     );
     let proposer_index = get_beacon_proposer_index(state, context)?;
     let whistleblower_index = whistleblower_index.unwrap_or(proposer_index);
@@ -2051,8 +2051,8 @@ pub fn get_base_reward_per_increment<
     >,
     context: &Context,
 ) -> Result<Gwei> {
-    Ok(context.effective_balance_increment * context.base_reward_factor
-        / get_total_active_balance(state, context)?.integer_sqrt())
+    Ok(context.effective_balance_increment * context.base_reward_factor /
+        get_total_active_balance(state, context)?.integer_sqrt())
 }
 pub fn get_unslashed_participating_indices<
     const SLOTS_PER_HISTORICAL_ROOT: usize,
@@ -2090,7 +2090,7 @@ pub fn get_unslashed_participating_indices<
             requested: epoch,
             previous: previous_epoch,
             current: current_epoch,
-        });
+        })
     }
     let epoch_participation = if is_current {
         &state.current_epoch_participation
@@ -2164,8 +2164,8 @@ pub fn is_active_validator(validator: &Validator, epoch: Epoch) -> bool {
     validator.activation_epoch <= epoch && epoch < validator.exit_epoch
 }
 pub fn is_eligible_for_activation_queue(validator: &Validator, context: &Context) -> bool {
-    validator.activation_eligibility_epoch == FAR_FUTURE_EPOCH
-        && validator.effective_balance == context.max_effective_balance
+    validator.activation_eligibility_epoch == FAR_FUTURE_EPOCH &&
+        validator.effective_balance == context.max_effective_balance
 }
 pub fn is_eligible_for_activation<
     const SLOTS_PER_HISTORICAL_ROOT: usize,
@@ -2193,13 +2193,13 @@ pub fn is_eligible_for_activation<
     >,
     validator: &Validator,
 ) -> bool {
-    validator.activation_eligibility_epoch <= state.finalized_checkpoint.epoch
-        && validator.activation_epoch == FAR_FUTURE_EPOCH
+    validator.activation_eligibility_epoch <= state.finalized_checkpoint.epoch &&
+        validator.activation_epoch == FAR_FUTURE_EPOCH
 }
 pub fn is_slashable_validator(validator: &Validator, epoch: Epoch) -> bool {
-    !validator.slashed
-        && validator.activation_epoch <= epoch
-        && epoch < validator.withdrawable_epoch
+    !validator.slashed &&
+        validator.activation_epoch <= epoch &&
+        epoch < validator.withdrawable_epoch
 }
 pub fn is_slashable_attestation_data(data_1: &AttestationData, data_2: &AttestationData) -> bool {
     let double_vote = data_1 != data_2 && data_1.target.epoch == data_2.target.epoch;
@@ -2238,7 +2238,7 @@ pub fn is_valid_indexed_attestation<
     if attesting_indices.is_empty() {
         return Err(invalid_operation_error(InvalidOperation::IndexedAttestation(
             InvalidIndexedAttestation::AttestingIndicesEmpty,
-        )));
+        )))
     }
     let mut prev = attesting_indices[0];
     let mut duplicates = HashSet::new();
@@ -2246,7 +2246,7 @@ pub fn is_valid_indexed_attestation<
         if index < prev {
             return Err(invalid_operation_error(InvalidOperation::IndexedAttestation(
                 InvalidIndexedAttestation::AttestingIndicesNotSorted,
-            )));
+            )))
         }
         if index == prev {
             duplicates.insert(index);
@@ -2256,7 +2256,7 @@ pub fn is_valid_indexed_attestation<
     if !duplicates.is_empty() {
         return Err(invalid_operation_error(InvalidOperation::IndexedAttestation(
             InvalidIndexedAttestation::DuplicateIndices(Vec::from_iter(duplicates)),
-        )));
+        )))
     }
     let mut public_keys = vec![];
     for &index in &attesting_indices[..] {
@@ -2410,7 +2410,7 @@ pub fn compute_shuffled_index(
     context: &Context,
 ) -> Result<usize> {
     if index >= index_count {
-        return Err(Error::InvalidShufflingIndex { index, total: index_count });
+        return Err(Error::InvalidShufflingIndex { index, total: index_count })
     }
     let mut pivot_input = [0u8; 33];
     pivot_input[..32].copy_from_slice(seed.as_ref());
@@ -2461,7 +2461,7 @@ pub fn compute_proposer_index<
     context: &Context,
 ) -> Result<ValidatorIndex> {
     if indices.is_empty() {
-        return Err(Error::CollectionCannotBeEmpty);
+        return Err(Error::CollectionCannotBeEmpty)
     }
     let max_byte = u8::MAX as u64;
     let mut i = 0;
@@ -2476,7 +2476,7 @@ pub fn compute_proposer_index<
         let random_byte = hash(hash_input).as_ref()[i % 32] as u64;
         let effective_balance = state.validators[candidate_index].effective_balance;
         if effective_balance * max_byte >= context.max_effective_balance * random_byte {
-            return Ok(candidate_index);
+            return Ok(candidate_index)
         }
         i += 1;
     }
@@ -2630,7 +2630,7 @@ pub fn get_block_root_at_slot<
             requested: slot,
             lower_bound: state.slot - 1,
             upper_bound: state.slot + SLOTS_PER_HISTORICAL_ROOT as Slot,
-        });
+        })
     }
     Ok(&state.block_roots[slot as usize % SLOTS_PER_HISTORICAL_ROOT])
 }
@@ -2797,9 +2797,9 @@ pub fn get_committee_count_per_slot<
         1,
         u64::min(
             context.max_committees_per_slot,
-            get_active_validator_indices(state, epoch).len() as u64
-                / context.slots_per_epoch
-                / context.target_committee_size,
+            get_active_validator_indices(state, epoch).len() as u64 /
+                context.slots_per_epoch /
+                context.target_committee_size,
         ),
     ) as usize
 }
@@ -3007,7 +3007,7 @@ pub fn get_attesting_indices<
     if bits.len() != committee.len() {
         return Err(invalid_operation_error(InvalidOperation::Attestation(
             InvalidAttestation::Bitfield { expected_length: committee.len(), length: bits.len() },
-        )));
+        )))
     }
     let mut indices = HashSet::with_capacity(bits.capacity());
     for (i, validator_index) in committee.iter().enumerate() {
@@ -3107,7 +3107,7 @@ pub fn initiate_validator_exit<
     context: &Context,
 ) {
     if state.validators[index].exit_epoch != FAR_FUTURE_EPOCH {
-        return;
+        return
     }
     let mut exit_epochs: Vec<Epoch> = state
         .validators
@@ -3155,8 +3155,8 @@ pub fn get_eligible_validator_indices<
 ) -> impl Iterator<Item = ValidatorIndex> + 'a {
     let previous_epoch = get_previous_epoch(state, context);
     state.validators.iter().enumerate().filter_map(move |(i, validator)| {
-        if is_active_validator(validator, previous_epoch)
-            || (validator.slashed && previous_epoch + 1 < validator.withdrawable_epoch)
+        if is_active_validator(validator, previous_epoch) ||
+            (validator.slashed && previous_epoch + 1 < validator.withdrawable_epoch)
         {
             Some(i)
         } else {
@@ -3192,7 +3192,7 @@ pub fn process_slots<
     context: &Context,
 ) -> Result<()> {
     if state.slot >= slot {
-        return Err(Error::TransitionToPreviousSlot { requested: slot, current: state.slot });
+        return Err(Error::TransitionToPreviousSlot { requested: slot, current: state.slot })
     }
     while state.slot < slot {
         process_slot(state, context)?;

--- a/ethereum-consensus/src/deneb/spec/mod.rs
+++ b/ethereum-consensus/src/deneb/spec/mod.rs
@@ -33,8 +33,7 @@ pub use crate::{
         },
         blinded_blob_sidecar::{BlindedBlobSidecar, SignedBlindedBlobSidecar},
         blob_sidecar::{
-            Blob, BlobIdentifier, BlobSidecar, SignedBlobSidecar, BLOB_TX_TYPE,
-            VERSIONED_HASH_VERSION_KZG,
+            Blob, BlobIdentifier, BlobSidecar, BLOB_TX_TYPE, VERSIONED_HASH_VERSION_KZG,
         },
         block_processing::{
             process_attestation, process_block, process_execution_payload, process_voluntary_exit,
@@ -111,14 +110,14 @@ pub fn process_bls_to_execution_change<
     if address_change.validator_index >= state.validators.len() {
         return Err(invalid_operation_error(InvalidOperation::BlsToExecutionChange(
             InvalidBlsToExecutionChange::ValidatorIndexOutOfBounds(address_change.validator_index),
-        )))
+        )));
     }
     let withdrawal_credentials =
         &mut state.validators[address_change.validator_index].withdrawal_credentials;
     if withdrawal_credentials[0] != BLS_WITHDRAWAL_PREFIX {
         return Err(invalid_operation_error(InvalidOperation::BlsToExecutionChange(
             InvalidBlsToExecutionChange::WithdrawalCredentialsPrefix(withdrawal_credentials[0]),
-        )))
+        )));
     }
     let domain = compute_domain(
         DomainType::BlsToExecutionChange,
@@ -131,7 +130,7 @@ pub fn process_bls_to_execution_change<
     if withdrawal_credentials[1..] != hash(public_key.as_ref())[1..] {
         return Err(invalid_operation_error(InvalidOperation::BlsToExecutionChange(
             InvalidBlsToExecutionChange::PublicKeyMismatch(public_key.clone()),
-        )))
+        )));
     }
     verify_signature(public_key, signing_root.as_ref(), signature)?;
     withdrawal_credentials[0] = ETH1_ADDRESS_WITHDRAWAL_PREFIX;
@@ -201,7 +200,7 @@ pub fn process_operations<
                 expected: expected_deposit_count,
                 count: body.deposits.len(),
             },
-        )))
+        )));
     }
     body.proposer_slashings
         .iter_mut()
@@ -262,7 +261,7 @@ pub fn process_withdrawals<
                 provided: execution_payload.withdrawals.to_vec(),
                 expected: expected_withdrawals,
             },
-        )))
+        )));
     }
     for withdrawal in &expected_withdrawals {
         decrease_balance(state, withdrawal.validator_index, withdrawal.amount);
@@ -339,7 +338,7 @@ pub fn get_expected_withdrawals<
             withdrawal_index += 1;
         }
         if withdrawals.len() == context.max_withdrawals_per_payload {
-            break
+            break;
         }
         validator_index = (validator_index + 1) % state.validators.len();
     }
@@ -384,7 +383,7 @@ pub fn process_deposit<
     if !is_valid_merkle_branch(&leaf, branch.iter(), depth, index, root) {
         return Err(invalid_operation_error(InvalidOperation::Deposit(
             InvalidDeposit::InvalidProof { leaf, branch, depth, index, root: *root },
-        )))
+        )));
     }
     state.eth1_deposit_index += 1;
     let public_key = &deposit.data.public_key;
@@ -400,7 +399,7 @@ pub fn process_deposit<
         let domain = compute_domain(DomainType::Deposit, None, None, context)?;
         let signing_root = compute_signing_root(&mut deposit_message, domain)?;
         if verify_signature(public_key, signing_root.as_ref(), &deposit.data.signature).is_err() {
-            return Ok(())
+            return Ok(());
         }
         state.validators.push(get_validator_from_deposit(deposit, context));
         state.balances.push(amount);
@@ -466,7 +465,7 @@ pub fn process_sync_aggregate<
                 signature: sync_aggregate.sync_committee_signature.clone(),
                 root: signing_root,
             },
-        )))
+        )));
     }
     let total_active_increments =
         get_total_active_balance(state, context)? / context.effective_balance_increment;
@@ -532,7 +531,7 @@ pub fn process_proposer_slashing<
     if header_1.slot != header_2.slot {
         return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
             InvalidProposerSlashing::SlotMismatch(header_1.slot, header_2.slot),
-        )))
+        )));
     }
     if header_1.proposer_index != header_2.proposer_index {
         return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
@@ -540,12 +539,12 @@ pub fn process_proposer_slashing<
                 header_1.proposer_index,
                 header_2.proposer_index,
             ),
-        )))
+        )));
     }
     if header_1 == header_2 {
         return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
             InvalidProposerSlashing::HeadersAreEqual(header_1.clone()),
-        )))
+        )));
     }
     let proposer_index = header_1.proposer_index;
     let proposer = state.validators.get(proposer_index).ok_or_else(|| {
@@ -556,7 +555,7 @@ pub fn process_proposer_slashing<
     if !is_slashable_validator(proposer, get_current_epoch(state, context)) {
         return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
             InvalidProposerSlashing::ProposerIsNotSlashable(header_1.proposer_index),
-        )))
+        )));
     }
     let epoch = compute_epoch_at_slot(header_1.slot, context);
     let domain = get_domain(state, DomainType::BeaconProposer, Some(epoch), context)?;
@@ -568,7 +567,7 @@ pub fn process_proposer_slashing<
         if verify_signature(public_key, signing_root.as_ref(), &signed_header.signature).is_err() {
             return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
                 InvalidProposerSlashing::InvalidSignature(signed_header.signature.clone()),
-            )))
+            )));
         }
     }
     slash_validator(state, proposer_index, None, context)
@@ -608,7 +607,7 @@ pub fn process_attester_slashing<
                 Box::new(attestation_1.data.clone()),
                 Box::new(attestation_2.data.clone()),
             ),
-        )))
+        )));
     }
     is_valid_indexed_attestation(state, attestation_1, context)?;
     is_valid_indexed_attestation(state, attestation_2, context)?;
@@ -706,27 +705,27 @@ pub fn process_block_header<
         return Err(invalid_header_error(InvalidBeaconBlockHeader::StateSlotMismatch {
             state_slot: state.slot,
             block_slot: block.slot,
-        }))
+        }));
     }
     if block.slot <= state.latest_block_header.slot {
         return Err(invalid_header_error(InvalidBeaconBlockHeader::OlderThanLatestBlockHeader {
             block_slot: block.slot,
             latest_block_header_slot: state.latest_block_header.slot,
-        }))
+        }));
     }
     let proposer_index = get_beacon_proposer_index(state, context)?;
     if block.proposer_index != proposer_index {
         return Err(invalid_header_error(InvalidBeaconBlockHeader::ProposerIndexMismatch {
             block_proposer_index: block.proposer_index,
             proposer_index,
-        }))
+        }));
     }
     let expected_parent_root = state.latest_block_header.hash_tree_root()?;
     if block.parent_root != expected_parent_root {
         return Err(invalid_header_error(InvalidBeaconBlockHeader::ParentBlockRootMismatch {
             expected: expected_parent_root,
             provided: block.parent_root,
-        }))
+        }));
     }
     state.latest_block_header = BeaconBlockHeader {
         slot: block.slot,
@@ -737,7 +736,7 @@ pub fn process_block_header<
     };
     let proposer = &state.validators[block.proposer_index];
     if proposer.slashed {
-        return Err(invalid_header_error(InvalidBeaconBlockHeader::ProposerSlashed(proposer_index)))
+        return Err(invalid_header_error(InvalidBeaconBlockHeader::ProposerSlashed(proposer_index)));
     }
     Ok(())
 }
@@ -803,7 +802,7 @@ pub fn process_randao<
     let domain = get_domain(state, DomainType::Randao, Some(epoch), context)?;
     let signing_root = compute_signing_root(&mut epoch, domain)?;
     if verify_signature(&proposer.public_key, signing_root.as_ref(), &body.randao_reveal).is_err() {
-        return Err(invalid_operation_error(InvalidOperation::Randao(body.randao_reveal.clone())))
+        return Err(invalid_operation_error(InvalidOperation::Randao(body.randao_reveal.clone())));
     }
     let mix = xor(get_randao_mix(state, epoch), &hash(body.randao_reveal.as_ref()));
     let mix_index = epoch % context.epochs_per_historical_vector;
@@ -979,8 +978,8 @@ pub fn process_slashings<
     );
     for i in 0..state.validators.len() {
         let validator = &state.validators[i];
-        if validator.slashed &&
-            (epoch + context.epochs_per_slashings_vector / 2) == validator.withdrawable_epoch
+        if validator.slashed
+            && (epoch + context.epochs_per_slashings_vector / 2) == validator.withdrawable_epoch
         {
             let increment = context.effective_balance_increment;
             let penalty_numerator =
@@ -1050,7 +1049,7 @@ pub fn process_justification_and_finalization<
 ) -> Result<()> {
     let current_epoch = get_current_epoch(state, context);
     if current_epoch <= GENESIS_EPOCH + 1 {
-        return Ok(())
+        return Ok(());
     }
     let previous_indices = get_unslashed_participating_indices(
         state,
@@ -1103,7 +1102,7 @@ pub fn process_inactivity_updates<
 ) -> Result<()> {
     let current_epoch = get_current_epoch(state, context);
     if current_epoch == GENESIS_EPOCH {
-        return Ok(())
+        return Ok(());
     }
     let eligible_validator_indices =
         get_eligible_validator_indices(state, context).collect::<Vec<_>>();
@@ -1155,7 +1154,7 @@ pub fn process_rewards_and_penalties<
 ) -> Result<()> {
     let current_epoch = get_current_epoch(state, context);
     if current_epoch == GENESIS_EPOCH {
-        return Ok(())
+        return Ok(());
     }
     let mut deltas = Vec::new();
     for flag_index in 0..PARTICIPATION_FLAG_WEIGHTS.len() {
@@ -1301,8 +1300,8 @@ pub fn process_effective_balance_updates<
     for i in 0..state.validators.len() {
         let validator = &mut state.validators[i];
         let balance = state.balances[i];
-        if balance + downward_threshold < validator.effective_balance ||
-            validator.effective_balance + upward_threshold < balance
+        if balance + downward_threshold < validator.effective_balance
+            || validator.effective_balance + upward_threshold < balance
         {
             validator.effective_balance = Gwei::min(
                 balance - balance % context.effective_balance_increment,
@@ -1586,10 +1585,10 @@ pub fn is_valid_genesis_state<
     context: &Context,
 ) -> bool {
     if state.genesis_time < context.min_genesis_time {
-        return false
+        return false;
     }
-    get_active_validator_indices(state, GENESIS_EPOCH).len() >=
-        context.min_genesis_active_validator_count
+    get_active_validator_indices(state, GENESIS_EPOCH).len()
+        >= context.min_genesis_active_validator_count
 }
 pub fn get_genesis_block<
     const SLOTS_PER_HISTORICAL_ROOT: usize,
@@ -1649,9 +1648,9 @@ pub fn has_eth1_withdrawal_credential(validator: &Validator) -> bool {
     validator.withdrawal_credentials[0] == ETH1_ADDRESS_WITHDRAWAL_PREFIX
 }
 pub fn is_fully_withdrawable_validator(validator: &Validator, balance: Gwei, epoch: Epoch) -> bool {
-    has_eth1_withdrawal_credential(validator) &&
-        validator.withdrawable_epoch <= epoch &&
-        balance > 0
+    has_eth1_withdrawal_credential(validator)
+        && validator.withdrawable_epoch <= epoch
+        && balance > 0
 }
 pub fn is_partially_withdrawable_validator(
     validator: &Validator,
@@ -1749,8 +1748,8 @@ pub fn slash_validator<
     decrease_balance(
         state,
         slashed_index,
-        state.validators[slashed_index].effective_balance /
-            context.min_slashing_penalty_quotient_bellatrix,
+        state.validators[slashed_index].effective_balance
+            / context.min_slashing_penalty_quotient_bellatrix,
     );
     let proposer_index = get_beacon_proposer_index(state, context)?;
     let whistleblower_index = whistleblower_index.unwrap_or(proposer_index);
@@ -2052,8 +2051,8 @@ pub fn get_base_reward_per_increment<
     >,
     context: &Context,
 ) -> Result<Gwei> {
-    Ok(context.effective_balance_increment * context.base_reward_factor /
-        get_total_active_balance(state, context)?.integer_sqrt())
+    Ok(context.effective_balance_increment * context.base_reward_factor
+        / get_total_active_balance(state, context)?.integer_sqrt())
 }
 pub fn get_unslashed_participating_indices<
     const SLOTS_PER_HISTORICAL_ROOT: usize,
@@ -2091,7 +2090,7 @@ pub fn get_unslashed_participating_indices<
             requested: epoch,
             previous: previous_epoch,
             current: current_epoch,
-        })
+        });
     }
     let epoch_participation = if is_current {
         &state.current_epoch_participation
@@ -2165,8 +2164,8 @@ pub fn is_active_validator(validator: &Validator, epoch: Epoch) -> bool {
     validator.activation_epoch <= epoch && epoch < validator.exit_epoch
 }
 pub fn is_eligible_for_activation_queue(validator: &Validator, context: &Context) -> bool {
-    validator.activation_eligibility_epoch == FAR_FUTURE_EPOCH &&
-        validator.effective_balance == context.max_effective_balance
+    validator.activation_eligibility_epoch == FAR_FUTURE_EPOCH
+        && validator.effective_balance == context.max_effective_balance
 }
 pub fn is_eligible_for_activation<
     const SLOTS_PER_HISTORICAL_ROOT: usize,
@@ -2194,13 +2193,13 @@ pub fn is_eligible_for_activation<
     >,
     validator: &Validator,
 ) -> bool {
-    validator.activation_eligibility_epoch <= state.finalized_checkpoint.epoch &&
-        validator.activation_epoch == FAR_FUTURE_EPOCH
+    validator.activation_eligibility_epoch <= state.finalized_checkpoint.epoch
+        && validator.activation_epoch == FAR_FUTURE_EPOCH
 }
 pub fn is_slashable_validator(validator: &Validator, epoch: Epoch) -> bool {
-    !validator.slashed &&
-        validator.activation_epoch <= epoch &&
-        epoch < validator.withdrawable_epoch
+    !validator.slashed
+        && validator.activation_epoch <= epoch
+        && epoch < validator.withdrawable_epoch
 }
 pub fn is_slashable_attestation_data(data_1: &AttestationData, data_2: &AttestationData) -> bool {
     let double_vote = data_1 != data_2 && data_1.target.epoch == data_2.target.epoch;
@@ -2239,7 +2238,7 @@ pub fn is_valid_indexed_attestation<
     if attesting_indices.is_empty() {
         return Err(invalid_operation_error(InvalidOperation::IndexedAttestation(
             InvalidIndexedAttestation::AttestingIndicesEmpty,
-        )))
+        )));
     }
     let mut prev = attesting_indices[0];
     let mut duplicates = HashSet::new();
@@ -2247,7 +2246,7 @@ pub fn is_valid_indexed_attestation<
         if index < prev {
             return Err(invalid_operation_error(InvalidOperation::IndexedAttestation(
                 InvalidIndexedAttestation::AttestingIndicesNotSorted,
-            )))
+            )));
         }
         if index == prev {
             duplicates.insert(index);
@@ -2257,7 +2256,7 @@ pub fn is_valid_indexed_attestation<
     if !duplicates.is_empty() {
         return Err(invalid_operation_error(InvalidOperation::IndexedAttestation(
             InvalidIndexedAttestation::DuplicateIndices(Vec::from_iter(duplicates)),
-        )))
+        )));
     }
     let mut public_keys = vec![];
     for &index in &attesting_indices[..] {
@@ -2411,7 +2410,7 @@ pub fn compute_shuffled_index(
     context: &Context,
 ) -> Result<usize> {
     if index >= index_count {
-        return Err(Error::InvalidShufflingIndex { index, total: index_count })
+        return Err(Error::InvalidShufflingIndex { index, total: index_count });
     }
     let mut pivot_input = [0u8; 33];
     pivot_input[..32].copy_from_slice(seed.as_ref());
@@ -2462,7 +2461,7 @@ pub fn compute_proposer_index<
     context: &Context,
 ) -> Result<ValidatorIndex> {
     if indices.is_empty() {
-        return Err(Error::CollectionCannotBeEmpty)
+        return Err(Error::CollectionCannotBeEmpty);
     }
     let max_byte = u8::MAX as u64;
     let mut i = 0;
@@ -2477,7 +2476,7 @@ pub fn compute_proposer_index<
         let random_byte = hash(hash_input).as_ref()[i % 32] as u64;
         let effective_balance = state.validators[candidate_index].effective_balance;
         if effective_balance * max_byte >= context.max_effective_balance * random_byte {
-            return Ok(candidate_index)
+            return Ok(candidate_index);
         }
         i += 1;
     }
@@ -2631,7 +2630,7 @@ pub fn get_block_root_at_slot<
             requested: slot,
             lower_bound: state.slot - 1,
             upper_bound: state.slot + SLOTS_PER_HISTORICAL_ROOT as Slot,
-        })
+        });
     }
     Ok(&state.block_roots[slot as usize % SLOTS_PER_HISTORICAL_ROOT])
 }
@@ -2798,9 +2797,9 @@ pub fn get_committee_count_per_slot<
         1,
         u64::min(
             context.max_committees_per_slot,
-            get_active_validator_indices(state, epoch).len() as u64 /
-                context.slots_per_epoch /
-                context.target_committee_size,
+            get_active_validator_indices(state, epoch).len() as u64
+                / context.slots_per_epoch
+                / context.target_committee_size,
         ),
     ) as usize
 }
@@ -3008,7 +3007,7 @@ pub fn get_attesting_indices<
     if bits.len() != committee.len() {
         return Err(invalid_operation_error(InvalidOperation::Attestation(
             InvalidAttestation::Bitfield { expected_length: committee.len(), length: bits.len() },
-        )))
+        )));
     }
     let mut indices = HashSet::with_capacity(bits.capacity());
     for (i, validator_index) in committee.iter().enumerate() {
@@ -3108,7 +3107,7 @@ pub fn initiate_validator_exit<
     context: &Context,
 ) {
     if state.validators[index].exit_epoch != FAR_FUTURE_EPOCH {
-        return
+        return;
     }
     let mut exit_epochs: Vec<Epoch> = state
         .validators
@@ -3156,8 +3155,8 @@ pub fn get_eligible_validator_indices<
 ) -> impl Iterator<Item = ValidatorIndex> + 'a {
     let previous_epoch = get_previous_epoch(state, context);
     state.validators.iter().enumerate().filter_map(move |(i, validator)| {
-        if is_active_validator(validator, previous_epoch) ||
-            (validator.slashed && previous_epoch + 1 < validator.withdrawable_epoch)
+        if is_active_validator(validator, previous_epoch)
+            || (validator.slashed && previous_epoch + 1 < validator.withdrawable_epoch)
         {
             Some(i)
         } else {
@@ -3193,7 +3192,7 @@ pub fn process_slots<
     context: &Context,
 ) -> Result<()> {
     if state.slot >= slot {
-        return Err(Error::TransitionToPreviousSlot { requested: slot, current: state.slot })
+        return Err(Error::TransitionToPreviousSlot { requested: slot, current: state.slot });
     }
     while state.slot < slot {
         process_slot(state, context)?;


### PR DESCRIPTION
Fixes https://github.com/ralexstokes/ethereum-consensus/issues/306.

Note:  `kzg_commitment_inclusion_proof` is a vector of `Bytes32` in python spec.  
Do we want it to be an array?

`pub kzg_commitment_inclusion_proof = [Bytes32; KZG_COMMITMENT_INCLUSION_PROOF_DEPTH]`