### PR TITLE
fix for HOLESKY_GENESIS_TIME

### DIFF
--- a/ethereum-consensus/src/clock.rs
+++ b/ethereum-consensus/src/clock.rs
@@ -12,7 +12,7 @@ use std::{
 pub const MAINNET_GENESIS_TIME: u64 = 1606824023;
 pub const SEPOLIA_GENESIS_TIME: u64 = 1655733600;
 pub const GOERLI_GENESIS_TIME: u64 = 1616508000;
-pub const HOLESKY_GENESIS_TIME: u64 = 1694786400;
+pub const HOLESKY_GENESIS_TIME: u64 = 1695902400;
 
 fn slot_to_nanos(slot: Slot, seconds_per_slot: u128, genesis_time: u128) -> u128 {
     u128::from(slot) * seconds_per_slot + genesis_time


### PR DESCRIPTION
The current holesky time stamp is wrong.

For example the timestamp of slot [308297](https://holesky.beaconcha.in/slot/308297) is 1699601964.
Using the correct genesis time we have 1695902400 + (308297 * 12) == 1699601964.
However, using the timestamp in the repo atm we have 1694786400 + (308297 * 12) == 1698485964.