### PR TITLE
fix: `rustls` feature for beacon api client

### DIFF
--- a/beacon-api-client/Cargo.toml
+++ b/beacon-api-client/Cargo.toml
@@ -9,8 +9,8 @@ license = "MIT OR Apache-2.0"
 [features]
 default = ["cli", "native-tls"]
 cli = ["clap"]
-rustls = ["reqwest/rustls-tls"]
-native-tls = ["reqwest/default-tls"]
+rustls = ["reqwest/rustls-tls", "mev-share-sse/rustls"]
+native-tls = ["reqwest/default-tls", "mev-share-sse/native-tls"]
 
 [dependencies]
 tokio = { version = "1.0", features = ["full"] }
@@ -19,7 +19,7 @@ reqwest = { version = "0.11.10", default-features = false, features = ["json"] }
 url = "2.2.2"
 http = "0.2.7"
 
-mev-share-sse = { git = "https://github.com/paradigmxyz/mev-share-rs", rev = "93c8ef00c8c840b69e2dc8107f1e4212d7eb6dfa" }
+mev-share-sse = { git = "https://github.com/paradigmxyz/mev-share-rs", rev = "9eb2b0138ab3202b9eb3af4b19c7b3bf40b0faa8", default-features = false }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.81"


### PR DESCRIPTION
## Description

Fix `rustls` feature by toggling `tls` features on `mev-share-sse` dependency.

Before:
```sh
➜ cargo tree -p beacon-api-client --no-default-features --features rustls --target all | grep openssl
│   │   │   │   ├── openssl v0.10.61
│   │   │   │   │   ├── openssl-macros v0.1.1 (proc-macro)
│   │   │   │   │   └── openssl-sys v0.9.97
│   │   │   │   ├── openssl-probe v0.1.5
│   │   │   │   ├── openssl-sys v0.9.97 (*)
```

After:
```sh
➜ cargo tree -p beacon-api-client --no-default-features --features rustls --target all | grep openssl
<no output>
```