### PR TITLE
Place crate dependencies in workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,44 @@ resolver = "2"
 
 members = ["beacon-api-client", "ethereum-consensus", "test-gen", "spec-gen"]
 default-members = ["ethereum-consensus"]
+
+[workspace.dependencies]
+tokio = { version = "1.0", features = ["full"] }
+tracing = "0.1"
+reqwest = { version = "0.11.10", default-features = false, features = ["json"] }
+url = "2.2.2"
+http = "0.2.7"
+
+mev-share-sse = { git = "https://github.com/paradigmxyz/mev-share-rs", rev = "9eb2b0138ab3202b9eb3af4b19c7b3bf40b0faa8", default-features = false }
+
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.81"
+itertools = "0.10.3"
+thiserror = "1.0.30"
+
+ssz_rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "ec96b6c989e3b9e13148f3022815a69781d53230" }
+blst = "0.3.11"
+rand = "0.8.4"
+sha2 = "0.10.8"
+integer-sqrt = "0.1.5"
+enr = "0.6.2"
+multihash = { version = "0.16", default-features = false, features = [
+    "std",
+    "multihash-impl",
+    "identity",
+    "sha2",
+] }
+multiaddr = "0.14.0"
+c-kzg = "0.4.0"
+bs58 = "0.4.0"
+syn = { version = "1.0.98", features = [
+    "full",
+    "visit",
+    "visit-mut",
+    "extra-traits",
+] }
+prettyplease = { version = "0.1.10" }
+quote = { version = "1.0.18" }
+clap = { version = "4.4.6", features = ["derive"] }
+convert_case = "0.6.0"
+walkdir = "2.3.3"

--- a/beacon-api-client/Cargo.toml
+++ b/beacon-api-client/Cargo.toml
@@ -13,19 +13,19 @@ rustls = ["reqwest/rustls-tls", "mev-share-sse/rustls"]
 native-tls = ["reqwest/default-tls", "mev-share-sse/native-tls"]
 
 [dependencies]
-tokio = { version = "1.0", features = ["full"] }
-tracing = "0.1"
-reqwest = { version = "0.11.10", default-features = false, features = ["json"] }
-url = "2.2.2"
-http = "0.2.7"
+tokio = { workspace = true }
+tracing = { workspace = true }
+reqwest =  { workspace = true }
+url = { workspace = true }
+http = { workspace = true }
 
-mev-share-sse = { git = "https://github.com/paradigmxyz/mev-share-rs", rev = "9eb2b0138ab3202b9eb3af4b19c7b3bf40b0faa8", default-features = false }
+mev-share-sse = { workspace = true }
 
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.81"
-itertools = "0.10.3"
+serde = { workspace = true }
+serde_json = { workspace = true }
+itertools = { workspace = true }
 clap = { version = "4.3.11", features = ["derive"], optional = true }
-thiserror = "1.0.30"
+thiserror = { workspace = true }
 ethereum-consensus = { path = "../ethereum-consensus" }
 
 [dev-dependencies]

--- a/ethereum-consensus/Cargo.toml
+++ b/ethereum-consensus/Cargo.toml
@@ -31,23 +31,18 @@ ec = [
 ]
 
 [dependencies]
-ssz_rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "ec96b6c989e3b9e13148f3022815a69781d53230" }
-blst = "0.3.11"
-rand = "0.8.4"
-thiserror = "1.0.30"
-sha2 = "0.10.8"
-integer-sqrt = "0.1.5"
-enr = "0.6.2"
-multihash = { version = "0.16", default-features = false, features = [
-    "std",
-    "multihash-impl",
-    "identity",
-    "sha2",
-] }
-multiaddr = "0.14.0"
-c-kzg = "0.4.0"
+ssz_rs = { workspace = true }
+blst = { workspace = true }
+rand = { workspace = true }
+thiserror = { workspace = true }
+sha2 = { workspace = true }
+integer-sqrt = { workspace = true }
+enr = { workspace = true }
+multihash = { workspace = true }
+multiaddr = { workspace = true }
+c-kzg = { workspace = true }
 
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true }
 serde_json = { version = "1.0.81", optional = true }
 serde_yaml = { version = "0.8", optional = true }
 hex = { version = "0.4.3", optional = true }
@@ -56,7 +51,7 @@ tokio = { version = "1.18.2", features = ["full"], optional = true }
 tokio-stream = { version = "0.1.8", optional = true }
 async-stream = { version = "0.3.3", optional = true }
 
-bs58 = "0.4.0"
+bs58 = { workspace = true }
 
 clap = { version = "4.4.4", optional = true, features = ["derive"] }
 eyre = { version = "0.6.8", optional = true }

--- a/spec-gen/Cargo.toml
+++ b/spec-gen/Cargo.toml
@@ -8,13 +8,8 @@ readme = "./README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn = { version = "1.0.98", features = [
-    "full",
-    "visit",
-    "visit-mut",
-    "extra-traits",
-] }
-prettyplease = { version = "0.1.10" }
-quote = { version = "1.0.18" }
-clap = { version = "4.4.6", features = ["derive"] }
-convert_case = "0.6.0"
+syn = { workspace = true }
+prettyplease = { workspace = true } 
+quote = { workspace = true }
+clap = { workspace = true }
+convert_case = { workspace = true }

--- a/test-gen/Cargo.toml
+++ b/test-gen/Cargo.toml
@@ -8,5 +8,5 @@ readme = "./README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-convert_case = "0.6.0"
-walkdir = "2.3.3"
+convert_case = { workspace = true }
+walkdir = { workspace = true }


### PR DESCRIPTION
Fixes #325

i wasn't sure whether to add `dev-dependencies` to `[workspace.dependencies]`, so i didn't. 