### PR TITLE
refactor `spec-tests` macros

### DIFF
--- a/spec-tests/runners/bls.rs
+++ b/spec-tests/runners/bls.rs
@@ -16,50 +16,44 @@ use std::fmt;
 
 pub fn dispatch(test: &TestCase) -> Result<(), Error> {
     let meta = &test.meta;
+    let path = &test.data_path;
     match meta.handler.0.as_str() {
         "eth_aggregate_pubkeys" => {
-            let path = &test.data_path;
             let test_case = EthAggregatePubkeysTestCase::from(path);
             test_case.execute();
             Ok(())
         }
         "eth_fast_aggregate_verify" => {
-            let path = &test.data_path;
             let test_case = EthFastAggregateVerifyTestCase::from(path);
             test_case.execute();
             Ok(())
         }
         "verify" => {
-            let path = &test.data_path;
             let test_case = VerifyTestCase::from(path);
             test_case.execute();
             Ok(())
         }
         "aggregate" => {
-            let path = &test.data_path;
             let test_case = AggregateTestCase::from(path);
             test_case.execute();
             Ok(())
         }
         "fast_aggregate_verify" => {
-            let path = &test.data_path;
             let test_case = FastAggregateVerifyTestCase::from(path);
             test_case.execute();
             Ok(())
         }
         "aggregate_verify" => {
-            let path = &test.data_path;
             let test_case = AggregateVerifyTestCase::from(path);
             test_case.execute();
             Ok(())
         }
         "sign" => {
-            let path = &test.data_path;
             let test_case = SignTestCase::from(path);
             test_case.execute();
             Ok(())
         }
-        handler => Err(Error::UnknownHandler(handler.into(), meta.name())),
+        handler => unreachable!("no tests for {handler}"),
     }
 }
 

--- a/spec-tests/runners/random.rs
+++ b/spec-tests/runners/random.rs
@@ -1,5 +1,5 @@
 use crate::{
-    runners::{gen_dispatch, gen_exec},
+    runners::{gen_exec, gen_match_for_all},
     test_case::TestCase,
     test_utils::{load_snappy_ssz, load_yaml, Error},
 };
@@ -33,49 +33,17 @@ fn load_test<S: ssz_rs::Deserialize, B: ssz_rs::Deserialize>(
     (pre, post, blocks)
 }
 
-macro_rules! run_test {
-    ($context:expr, $pre:ident, $post: ident, $blocks:ident) => {
-        let mut pre = $pre;
-        let mut blocks = $blocks;
-        for block in blocks.iter_mut() {
-            todo!(/*
-                TODO: move exec engine as member of `Context`
-                spec::state_transition(&mut pre, block, Validation::Enabled, $context).map_err(Error::from)?;
-                 */);
-        }
-        let result = Ok::<_, Error>(());
-        if let Some(post) = $post {
-            assert_eq!(result.unwrap(), ());
-            if pre == post {
-                Ok(())
-            } else {
-                Err(Error::InvalidState)
-            }
-        } else {
-            if result.is_err() {
-                Ok(())
-            } else {
-                Err(Error::ExpectedError)
-            }
-        }
-    };
-}
-
 pub fn dispatch(test: &TestCase) -> Result<(), Error> {
-    let meta = &test.meta;
-    let path = &test.data_path;
-    match meta.handler.0.as_str() {
+    match test.meta.handler.0.as_str() {
         "random" => {
-            gen_dispatch! {
-                path,
-                meta.config,
-                meta.fork,
-                |path| { load_test::<spec::BeaconState, spec::SignedBeaconBlock>(path) },
-                |(pre, post, blocks): (spec::BeaconState, Option<spec::BeaconState>, Vec<spec::SignedBeaconBlock>), context| {
-                    run_test! { context, pre, post, blocks }
+            gen_match_for_all! {
+                test,
+                load_test,
+                |(pre, post, blocks): (spec::BeaconState, Option<spec::BeaconState>, Vec<spec::SignedBeaconBlock>), _context| {
+                    crate::runners::sanity::run_test(pre, post, blocks, _context)
                 }
             }
         }
-        handler => Err(Error::UnknownHandler(handler.into(), meta.name())),
+        handler => unreachable!("no tests for {handler}"),
     }
 }

--- a/spec-tests/runners/shuffling.rs
+++ b/spec-tests/runners/shuffling.rs
@@ -1,5 +1,5 @@
 use crate::{
-    runners::{gen_dispatch, gen_exec},
+    runners::{gen_exec, gen_match_for_all},
     test_case::TestCase,
     test_utils::{load_yaml, Error},
 };
@@ -19,14 +19,10 @@ fn load_test(test_case_path: &str) -> ShufflingTestData {
 }
 
 pub fn dispatch(test: &TestCase) -> Result<(), Error> {
-    let meta = &test.meta;
-    let path = &test.data_path;
-    match meta.handler.0.as_str() {
+    match test.meta.handler.0.as_str() {
         "core" => {
-            gen_dispatch! {
-                path,
-                meta.config,
-                meta.fork,
+            gen_match_for_all! {
+                test,
                 load_test,
                 |data: ShufflingTestData, context| {
                     for index in 0..data.count {
@@ -37,6 +33,6 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                 }
             }
         }
-        handler => Err(Error::UnknownHandler(handler.into(), meta.name())),
+        handler => unreachable!("no tests for {handler}"),
     }
 }

--- a/spec-tests/runners/transition.rs
+++ b/spec-tests/runners/transition.rs
@@ -4,10 +4,7 @@ use crate::{
     test_meta::{Config, Fork},
     test_utils::{load_snappy_ssz, load_yaml, Error},
 };
-use ethereum_consensus::{
-    primitives::Epoch,
-    state_transition::{Context, Executor},
-};
+use ethereum_consensus::{primitives::Epoch, state_transition::Context};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -57,9 +54,19 @@ fn load_test<
     (pre, post, pre_blocks, post_blocks, meta)
 }
 
-macro_rules! run_test {
-    ($context:expr, $meta:ident, $pre:ident, $post: ident, $pre_blocks:ident, $post_blocks:ident) => {
-        todo!(/*
+fn run_test<S: Eq, T, B, C>(
+    _pre: S,
+    _expected: T,
+    mut _pre_blocks: Vec<B>,
+    mut _post_blocks: Vec<C>,
+    meta: &Meta,
+    _context: &Context,
+) -> Result<(), Error> {
+    todo!(
+        "read for now to silence warning... {} {}",
+        meta.post_fork,
+        meta.fork_epoch,
+        /*
         let mut context = $context.clone();
         let meta = $meta;
         match meta.post_fork.as_ref() {
@@ -117,26 +124,23 @@ macro_rules! run_test {
                 }
              */
         )
-        */)
-    };
+        */
+    )
 }
 
 pub fn dispatch(test: &TestCase) -> Result<(), Error> {
-    let meta = &test.meta;
-    let path = &test.data_path;
-    match meta.handler.0.as_str() {
-        "core" => match meta.config {
-            Config::Mainnet => match meta.fork {
+    match test.meta.handler.0.as_str() {
+        "core" => match test.meta.config {
+            Config::Mainnet => match test.meta.fork {
                 Fork::Altair => {
                     use ethereum_consensus::{
                         altair::mainnet as spec, phase0::mainnet as pre_spec,
                     };
                     gen_exec! {
-                        path,
-                        meta.config,
-                        |path| { load_test::<pre_spec::BeaconState, spec::BeaconState, pre_spec::SignedBeaconBlock, spec::SignedBeaconBlock>(path)},
-                        |(pre, expected, pre_blocks, post_blocks, meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
-                            run_test! { context, meta, pre, expected, pre_blocks, post_blocks }
+                        test,
+                        load_test,
+                        | (pre, expected, pre_blocks, post_blocks, meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
+                            run_test(pre, expected, pre_blocks, post_blocks, &meta, context)
                         }
                     }
                 }
@@ -145,19 +149,18 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                         altair::mainnet as pre_spec, bellatrix::mainnet as spec,
                     };
                     gen_exec! {
-                        path,
-                        meta.config,
-                        |path| { load_test::<pre_spec::BeaconState, spec::BeaconState, pre_spec::SignedBeaconBlock, spec::SignedBeaconBlock>(path)},
-                        |(pre, expected, pre_blocks, post_blocks, meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
-                            run_test! { context, meta, pre, expected, pre_blocks, post_blocks }
+                        test,
+                        load_test,
+                        | (pre, expected, pre_blocks, post_blocks, meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
+                            run_test(pre, expected, pre_blocks, post_blocks, &meta, context)
                         }
                     }
                 }
-                _ => todo!(),
+                _ => todo!("implement after `run_test`"),
             },
-            Config::Minimal => todo!(),
-            _ => unreachable!(),
+            Config::Minimal => todo!("implement after `run_test`"),
+            config => unreachable!("no tests for {config:?}"),
         },
-        handler => Err(Error::UnknownHandler(handler.into(), meta.name())),
+        handler => unreachable!("no tests for {handler}"),
     }
 }

--- a/spec-tests/test_case.rs
+++ b/spec-tests/test_case.rs
@@ -4,22 +4,33 @@ use crate::{
         shuffling, ssz_static, transition,
     },
     test_meta::TestMeta,
+    Config, Context,
     Runner::*,
 };
-use std::{error::Error, path::Path};
+use ethereum_consensus::state_transition;
+use std::{error::Error, path::Path, sync::Arc};
 
 pub struct TestCase {
     pub meta: TestMeta,
     pub data_path: String,
+    pub context: Arc<Context>,
 }
 
 impl TestCase {
-    pub fn new(meta: TestMeta, data_path: &Path) -> Self {
-        Self { meta, data_path: data_path.as_os_str().to_str().unwrap().into() }
+    pub fn new(meta: TestMeta, data_path: &Path, context: Arc<Context>) -> Self {
+        Self { meta, data_path: data_path.as_os_str().to_str().unwrap().into(), context }
     }
 
     pub fn name(&self) -> String {
         self.meta.name()
+    }
+
+    pub fn context(&self) -> &state_transition::Context {
+        match self.meta.config {
+            Config::Mainnet => &self.context.mainnet,
+            Config::Minimal => &self.context.minimal,
+            _ => unreachable!(),
+        }
     }
 
     pub fn execute(&self) -> Result<(), Box<dyn Error>> {

--- a/spec-tests/test_meta.rs
+++ b/spec-tests/test_meta.rs
@@ -1,7 +1,7 @@
 use heck::ToSnakeCase;
 use std::fmt;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Config {
     General,
     Minimal,
@@ -26,7 +26,7 @@ impl fmt::Display for Config {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Fork {
     Phase0,
     Altair,

--- a/spec-tests/test_utils.rs
+++ b/spec-tests/test_utils.rs
@@ -5,8 +5,6 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("unknown handler `{0}` in `{1}`")]
-    UnknownHandler(String, String),
     #[error(transparent)]
     Spec(#[from] SpecError),
     #[error("state did not match expected")]


### PR DESCRIPTION
simplify the macros from #335 so there is less code and hopefully is easier to extend in the future

todo
- [x] `unroll` macro to deduplicate (Config, Fork) => body syntax
- [x] move `run_test` macros to functions