### PR TITLE
Update to latest version of `ssz-rs` with a variety of improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde_yaml = "0.8"
 itertools = "0.10.3"
 thiserror = "1.0.30"
 hex = "0.4.3"
-ssz_rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "13d2c7d1a0dc35a6dfbc2d657d5db95080cb44c0" }
+ssz_rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "9a238ce6385b6fe7745a7c7ff0c42a9315628da1" }
 blst = "0.3.11"
 rand = "0.8.4"
 sha2 = "0.10.8"

--- a/beacon-api-client/examples/get_block.rs
+++ b/beacon-api-client/examples/get_block.rs
@@ -1,5 +1,6 @@
 use beacon_api_client::{mainnet::Client, BlockId};
 use ethereum_consensus::primitives::Root;
+use hex::FromHex;
 use url::Url;
 
 #[tokio::main]
@@ -7,9 +8,8 @@ async fn main() {
     let url = Url::parse("http://localhost:5052").unwrap();
     let client = Client::new(url);
 
-    let root_hex =
-        hex::decode("421c16805c3416150aa04533fdfe7fc3f0880d0ed86cee33fa58011f10dd95c8").unwrap();
-    let root = Root::try_from(root_hex.as_ref()).unwrap();
+    let root_hex = "421c16805c3416150aa04533fdfe7fc3f0880d0ed86cee33fa58011f10dd95c8";
+    let root = Root::from_hex(root_hex).unwrap();
     let id = BlockId::Root(root);
 
     let block = client.get_beacon_block(id).await.unwrap();

--- a/beacon-api-client/src/types.rs
+++ b/beacon-api-client/src/types.rs
@@ -91,7 +91,7 @@ impl FromStr for StateId {
                 Ok(slot) => Ok(Self::Slot(slot)),
                 Err(_) => match try_bytes_from_hex_str(s) {
                     Ok(root_data) => {
-                        let root = Root::try_from(root_data.as_ref()).map_err(|err| format!("could not parse state identifier by root from the provided argument {s}: {err}"))?;
+                        let root = Root::try_from(root_data.as_slice()).map_err(|err| format!("could not parse state identifier by root from the provided argument {s}: {err}"))?;
                         Ok(Self::Root(root))
                     }
                     Err(err) => {

--- a/ethereum-consensus/src/altair/block_processing.rs
+++ b/ethereum-consensus/src/altair/block_processing.rs
@@ -189,16 +189,7 @@ pub fn process_deposit<
     let root = state.eth1_data.deposit_root;
     if is_valid_merkle_branch(leaf, branch, depth, index, root).is_err() {
         return Err(invalid_operation_error(InvalidOperation::Deposit(
-            InvalidDeposit::InvalidProof {
-                leaf,
-                branch: branch
-                    .iter()
-                    .map(|node| Node::try_from(node.as_ref()).expect("correct size"))
-                    .collect(),
-                depth,
-                index,
-                root,
-            },
+            InvalidDeposit::InvalidProof { leaf, branch: branch.to_vec(), depth, index, root },
         )))
     }
 

--- a/ethereum-consensus/src/bellatrix/spec/mod.rs
+++ b/ethereum-consensus/src/bellatrix/spec/mod.rs
@@ -216,16 +216,7 @@ pub fn process_deposit<
     let root = state.eth1_data.deposit_root;
     if is_valid_merkle_branch(leaf, branch, depth, index, root).is_err() {
         return Err(invalid_operation_error(InvalidOperation::Deposit(
-            InvalidDeposit::InvalidProof {
-                leaf,
-                branch: branch
-                    .iter()
-                    .map(|node| Node::try_from(node.as_ref()).expect("correct size"))
-                    .collect(),
-                depth,
-                index,
-                root,
-            },
+            InvalidDeposit::InvalidProof { leaf, branch: branch.to_vec(), depth, index, root },
         )));
     }
     state.eth1_deposit_index += 1;

--- a/ethereum-consensus/src/capella/spec/mod.rs
+++ b/ethereum-consensus/src/capella/spec/mod.rs
@@ -223,16 +223,7 @@ pub fn process_deposit<
     let root = state.eth1_data.deposit_root;
     if is_valid_merkle_branch(leaf, branch, depth, index, root).is_err() {
         return Err(invalid_operation_error(InvalidOperation::Deposit(
-            InvalidDeposit::InvalidProof {
-                leaf,
-                branch: branch
-                    .iter()
-                    .map(|node| Node::try_from(node.as_ref()).expect("correct size"))
-                    .collect(),
-                depth,
-                index,
-                root,
-            },
+            InvalidDeposit::InvalidProof { leaf, branch: branch.to_vec(), depth, index, root },
         )));
     }
     state.eth1_deposit_index += 1;

--- a/ethereum-consensus/src/deneb/blob_sidecar.rs
+++ b/ethereum-consensus/src/deneb/blob_sidecar.rs
@@ -4,7 +4,7 @@ use crate::{
         polynomial_commitments::{KzgCommitment, KzgProof},
         SignedBeaconBlockHeader,
     },
-    primitives::{BlobIndex, Bytes32, Root},
+    primitives::{BlobIndex, Root},
     ssz::prelude::*,
     Error,
 };
@@ -27,7 +27,7 @@ pub struct BlobSidecar<
     pub kzg_commitment: KzgCommitment,
     pub kzg_proof: KzgProof,
     pub signed_block_header: SignedBeaconBlockHeader,
-    pub kzg_commitment_inclusion_proof: Vector<Bytes32, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH>,
+    pub kzg_commitment_inclusion_proof: Vector<Node, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH>,
 }
 
 pub fn verify_blob_sidecar_inclusion_proof<

--- a/ethereum-consensus/src/deneb/spec/mod.rs
+++ b/ethereum-consensus/src/deneb/spec/mod.rs
@@ -381,16 +381,7 @@ pub fn process_deposit<
     let root = state.eth1_data.deposit_root;
     if is_valid_merkle_branch(leaf, branch, depth, index, root).is_err() {
         return Err(invalid_operation_error(InvalidOperation::Deposit(
-            InvalidDeposit::InvalidProof {
-                leaf,
-                branch: branch
-                    .iter()
-                    .map(|node| Node::try_from(node.as_ref()).expect("correct size"))
-                    .collect(),
-                depth,
-                index,
-                root,
-            },
+            InvalidDeposit::InvalidProof { leaf, branch: branch.to_vec(), depth, index, root },
         )));
     }
     state.eth1_deposit_index += 1;

--- a/ethereum-consensus/src/phase0/block_processing.rs
+++ b/ethereum-consensus/src/phase0/block_processing.rs
@@ -342,10 +342,7 @@ pub fn process_deposit<
         return Err(invalid_operation_error(InvalidOperation::Deposit(
             InvalidDeposit::InvalidProof {
                 leaf,
-                branch: branch
-                    .iter()
-                    .map(|node| Node::try_from(node.as_ref()).expect("correct size"))
-                    .collect(),
+                branch: branch.to_vec(),
                 depth: DEPOSIT_MERKLE_DEPTH,
                 index,
                 root,

--- a/ethereum-consensus/src/phase0/operations.rs
+++ b/ethereum-consensus/src/phase0/operations.rs
@@ -117,7 +117,7 @@ const DEPOSIT_PROOF_LENGTH: usize = get_deposit_proof_length();
     Default, Debug, SimpleSerialize, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize,
 )]
 pub struct Deposit {
-    pub proof: Vector<Bytes32, DEPOSIT_PROOF_LENGTH>,
+    pub proof: Vector<Node, DEPOSIT_PROOF_LENGTH>,
     pub data: DepositData,
 }
 

--- a/ethereum-consensus/src/ssz/byte_list.rs
+++ b/ethereum-consensus/src/ssz/byte_list.rs
@@ -1,5 +1,7 @@
-use crate::ssz::prelude::*;
-use ssz_rs::utils::{write_bytes_to_lower_hex, write_bytes_to_lower_hex_display};
+use crate::{
+    serde::{write_bytes_to_lower_hex, write_bytes_to_lower_hex_display},
+    ssz::prelude::*,
+};
 use std::{
     fmt,
     hash::{Hash, Hasher},

--- a/ethereum-consensus/src/ssz/byte_vector.rs
+++ b/ethereum-consensus/src/ssz/byte_vector.rs
@@ -1,5 +1,7 @@
-use crate::ssz::prelude::*;
-use ssz_rs::utils::{write_bytes_to_lower_hex, write_bytes_to_lower_hex_display};
+use crate::{
+    serde::{write_bytes_to_lower_hex, write_bytes_to_lower_hex_display},
+    ssz::prelude::*,
+};
 use std::{
     fmt,
     hash::{Hash, Hasher},

--- a/justfile
+++ b/justfile
@@ -8,8 +8,8 @@ gen-types:
 
 test:
     cargo test --all-features --all-targets --workspace --exclude spec-tests
-run-spec-tests:
-    cargo test -p spec-tests
+run-spec-tests filter="":
+    cargo test -p spec-tests {{filter}}
 fmt:
     cargo +nightly fmt --all
 lint: fmt

--- a/spec-tests/runners/light_client.rs
+++ b/spec-tests/runners/light_client.rs
@@ -9,7 +9,7 @@ use ethereum_consensus::Error as SpecError;
 use serde::Deserialize;
 use ssz_rs::{
     prelude::*,
-    proofs::{get_subtree_index, is_valid_merkle_branch_for_generalized_index, log_2, prove},
+    proofs::{get_subtree_index, is_valid_merkle_branch_for_generalized_index, log_2},
 };
 
 #[derive(Debug, Deserialize)]
@@ -42,7 +42,7 @@ fn path_from(meta: &TestMeta) -> Vec<PathElement> {
 pub fn run_test<O: SimpleSerialize>(mut object: O, path: Path, proof: &Proof) -> Result<(), Error> {
     let root = object.hash_tree_root().unwrap();
     // test proof matches
-    let (computed_proof, witness) = prove(&mut object, path).expect("can prove");
+    let (computed_proof, witness) = object.prove(path).expect("can prove");
     assert_eq!(root, witness);
     assert_eq!(proof.leaf, computed_proof.leaf);
     assert_eq!(proof.leaf_index, computed_proof.index);

--- a/spec-tests/runners/ssz_static.rs
+++ b/spec-tests/runners/ssz_static.rs
@@ -3,14 +3,14 @@ use crate::{
     test_case::TestCase,
     test_utils::{load_snappy_ssz_bytes, load_yaml, Error},
 };
-use ethereum_consensus::{primitives::Bytes32, state_transition::Context};
+use ethereum_consensus::{primitives::Root, state_transition::Context};
 use serde::Deserialize;
 use ssz_rs::prelude::*;
 use std::path::Path;
 
 #[derive(Deserialize)]
 struct RootData {
-    root: Bytes32,
+    root: Root,
 }
 
 fn load_test(test_case_path: &str) -> (RootData, Vec<u8>) {
@@ -31,7 +31,7 @@ fn run_test<T: ssz_rs::SimpleSerialize>(
     let serialized = serialize(&decoded_data).unwrap();
     let root = decoded_data.hash_tree_root().unwrap();
     assert_eq!(serialized, encoding);
-    assert_eq!(root.as_ref(), data.root.as_ref());
+    assert_eq!(root, data.root);
     Ok(())
 }
 


### PR DESCRIPTION
Main thing is updating the `ssz_rs::Node` type to use `alloy_primitives::B256`, and then removing or migrating some serialization code to simplify that crate.