### PR TITLE
Update to latest `ssz-rs`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           cache-on-failure: true
 
       - name: Build
-        run: cargo build --all-targets --all-features --verbose
+        run: cargo build --all-targets --all-features --workspace --verbose
 
       - name: Run tests
         run: cargo test --all-features --all-targets --workspace --exclude spec-tests --verbose
@@ -56,4 +56,4 @@ jobs:
         run: cargo +nightly fmt --all --check
 
       - name: Check clippy
-        run: cargo +nightly clippy --all-targets --all-features --verbose -- -D warnings
+        run: cargo +nightly clippy --all-targets --all-features --workspace --verbose -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde_yaml = "0.8"
 itertools = "0.10.3"
 thiserror = "1.0.30"
 hex = "0.4.3"
-ssz_rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "9a238ce6385b6fe7745a7c7ff0c42a9315628da1" }
+ssz_rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "8b2eb8ea06fd14227e5a16c85e79fccbed151a3b" }
 blst = "0.3.11"
 rand = "0.8.4"
 sha2 = "0.10.8"

--- a/ethereum-consensus/examples/sketch.rs
+++ b/ethereum-consensus/examples/sketch.rs
@@ -16,7 +16,7 @@ fn main() {
     let previous_epoch = phase0::get_previous_epoch(&state, &context);
     dbg!(previous_epoch);
 
-    let _ = phase0::state_transition(&mut state, &mut signed_block, Validation::Enabled, &context);
+    let _ = phase0::state_transition(&mut state, &signed_block, Validation::Enabled, &context);
     dbg!(state.fork);
 
     // altair transition
@@ -28,7 +28,7 @@ fn main() {
     let current_epoch = altair::get_current_epoch(&state, &context);
     dbg!(current_epoch);
 
-    let _ = altair::state_transition(&mut state, &mut signed_block, Validation::Enabled, &context);
+    let _ = altair::state_transition(&mut state, &signed_block, Validation::Enabled, &context);
     dbg!(state.fork);
 
     // bellatrix transition
@@ -40,7 +40,6 @@ fn main() {
     let current_epoch = bellatrix::get_current_epoch(&state, &context);
     dbg!(current_epoch);
 
-    let _ =
-        bellatrix::state_transition(&mut state, &mut signed_block, Validation::Enabled, &context);
+    let _ = bellatrix::state_transition(&mut state, &signed_block, Validation::Enabled, &context);
     dbg!(state.fork);
 }

--- a/ethereum-consensus/examples/state_transition_across_multiple_forks.rs
+++ b/ethereum-consensus/examples/state_transition_across_multiple_forks.rs
@@ -15,19 +15,19 @@ fn main() -> std::result::Result<(), Box<dyn Error>> {
 
     let mut block = SignedBeaconBlock::Phase0(Default::default());
     *block.message_mut().slot_mut() = 1;
-    executor.apply_block(&mut block)?;
+    executor.apply_block(&block)?;
 
     let mut block = SignedBeaconBlock::Altair(Default::default());
     *block.message_mut().slot_mut() =
         executor.context.altair_fork_epoch * executor.context.slots_per_epoch;
-    executor.apply_block(&mut block)?;
+    executor.apply_block(&block)?;
 
     let mut block = SignedBeaconBlock::Bellatrix(Default::default());
     *block.message_mut().slot_mut() =
         executor.context.bellatrix_fork_epoch * executor.context.slots_per_epoch;
-    executor.apply_block(&mut block)?;
+    executor.apply_block(&block)?;
 
-    let state = executor.state.bellatrix_mut().unwrap();
+    let state = executor.state.bellatrix().unwrap();
     let state_root = state.hash_tree_root()?;
     dbg!(state_root);
     Ok(())

--- a/ethereum-consensus/src/altair/block_processing.rs
+++ b/ethereum-consensus/src/altair/block_processing.rs
@@ -116,7 +116,7 @@ pub fn process_attestation<
     // Verify signature
     is_valid_indexed_attestation(
         state,
-        &mut get_indexed_attestation(state, attestation, context)?,
+        &get_indexed_attestation(state, attestation, context)?,
         context,
     )?;
 
@@ -225,8 +225,8 @@ pub fn process_sync_aggregate<
         Some(compute_epoch_at_slot(previous_slot, context)),
         context,
     )?;
-    let mut root_at_slot = *get_block_root_at_slot(state, previous_slot)?;
-    let signing_root = compute_signing_root(&mut root_at_slot, domain)?;
+    let root_at_slot = *get_block_root_at_slot(state, previous_slot)?;
+    let signing_root = compute_signing_root(&root_at_slot, domain)?;
     if eth_fast_aggregate_verify(
         participant_public_keys.as_slice(),
         signing_root.as_ref(),
@@ -304,7 +304,7 @@ pub fn process_block<
         MAX_VALIDATORS_PER_COMMITTEE,
         SYNC_COMMITTEE_SIZE,
     >,
-    block: &mut BeaconBlock<
+    block: &BeaconBlock<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -318,7 +318,7 @@ pub fn process_block<
     process_block_header(state, block, context)?;
     process_randao(state, &block.body, context)?;
     process_eth1_data(state, &block.body, context);
-    process_operations(state, &mut block.body, context)?;
+    process_operations(state, &block.body, context)?;
     process_sync_aggregate(state, &block.body.sync_aggregate, context)?;
     Ok(())
 }

--- a/ethereum-consensus/src/altair/genesis.rs
+++ b/ethereum-consensus/src/altair/genesis.rs
@@ -26,7 +26,7 @@ pub fn initialize_beacon_state_from_eth1<
 >(
     eth1_block_hash: Hash32,
     eth1_timestamp: u64,
-    deposits: &mut [Deposit],
+    deposits: &[Deposit],
     context: &Context,
 ) -> Result<
     BeaconState<
@@ -50,7 +50,7 @@ pub fn initialize_beacon_state_from_eth1<
         deposit_count: deposits.len() as u64,
         ..Default::default()
     };
-    let mut latest_block_body = BeaconBlockBody::<
+    let latest_block_body = BeaconBlockBody::<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -77,7 +77,7 @@ pub fn initialize_beacon_state_from_eth1<
     };
 
     let mut leaves = List::<DepositData, DEPOSIT_DATA_LIST_BOUND>::default();
-    for deposit in deposits.iter_mut() {
+    for deposit in deposits.iter() {
         leaves.push(deposit.data.clone());
         state.eth1_data.deposit_root = leaves.hash_tree_root()?;
         process_deposit(&mut state, deposit, context)?;

--- a/ethereum-consensus/src/bellatrix/block_processing.rs
+++ b/ethereum-consensus/src/bellatrix/block_processing.rs
@@ -42,7 +42,7 @@ pub fn process_execution_payload<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    block: &mut BeaconBlockBody<
+    block: &BeaconBlockBody<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -57,7 +57,7 @@ pub fn process_execution_payload<
     >,
     context: &Context,
 ) -> Result<()> {
-    let payload = &mut block.execution_payload;
+    let payload = &block.execution_payload;
 
     let parent_hash_invalid =
         payload.parent_hash != state.latest_execution_payload_header.block_hash;
@@ -148,7 +148,7 @@ pub fn process_block<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    block: &mut BeaconBlock<
+    block: &BeaconBlock<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -165,11 +165,11 @@ pub fn process_block<
 ) -> Result<()> {
     process_block_header(state, block, context)?;
     if is_execution_enabled(state, &block.body) {
-        process_execution_payload(state, &mut block.body, context)?;
+        process_execution_payload(state, &block.body, context)?;
     }
     process_randao(state, &block.body, context)?;
     process_eth1_data(state, &block.body, context);
-    process_operations(state, &mut block.body, context)?;
+    process_operations(state, &block.body, context)?;
     process_sync_aggregate(state, &block.body.sync_aggregate, context)?;
     Ok(())
 }

--- a/ethereum-consensus/src/bellatrix/execution_payload.rs
+++ b/ethereum-consensus/src/bellatrix/execution_payload.rs
@@ -88,7 +88,7 @@ impl<
         const MAX_TRANSACTIONS_PER_PAYLOAD: usize,
     >
     TryFrom<
-        &'a mut ExecutionPayload<
+        &'a ExecutionPayload<
             BYTES_PER_LOGS_BLOOM,
             MAX_EXTRA_DATA_BYTES,
             MAX_BYTES_PER_TRANSACTION,
@@ -99,7 +99,7 @@ impl<
     type Error = Error;
 
     fn try_from(
-        payload: &'a mut ExecutionPayload<
+        payload: &'a ExecutionPayload<
             BYTES_PER_LOGS_BLOOM,
             MAX_EXTRA_DATA_BYTES,
             MAX_BYTES_PER_TRANSACTION,

--- a/ethereum-consensus/src/bellatrix/genesis.rs
+++ b/ethereum-consensus/src/bellatrix/genesis.rs
@@ -29,7 +29,7 @@ pub fn initialize_beacon_state_from_eth1<
 >(
     eth1_block_hash: Hash32,
     eth1_timestamp: u64,
-    deposits: &mut [Deposit],
+    deposits: &[Deposit],
     execution_payload_header: Option<
         &ExecutionPayloadHeader<BYTES_PER_LOGS_BLOOM, MAX_EXTRA_DATA_BYTES>,
     >,
@@ -58,7 +58,7 @@ pub fn initialize_beacon_state_from_eth1<
         deposit_count: deposits.len() as u64,
         ..Default::default()
     };
-    let mut latest_block_body = BeaconBlockBody::<
+    let latest_block_body = BeaconBlockBody::<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -91,7 +91,7 @@ pub fn initialize_beacon_state_from_eth1<
     };
 
     let mut leaves = List::<DepositData, DEPOSIT_DATA_LIST_BOUND>::default();
-    for deposit in deposits.iter_mut() {
+    for deposit in deposits.iter() {
         leaves.push(deposit.data.clone());
         state.eth1_data.deposit_root = leaves.hash_tree_root()?;
         process_deposit(&mut state, deposit, context)?;

--- a/ethereum-consensus/src/bellatrix/state_transition.rs
+++ b/ethereum-consensus/src/bellatrix/state_transition.rs
@@ -41,7 +41,7 @@ pub fn state_transition_block_in_slot<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    signed_block: &mut SignedBeaconBlock<
+    signed_block: &SignedBeaconBlock<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -64,7 +64,7 @@ pub fn state_transition_block_in_slot<
     if validate_result {
         verify_block_signature(state, signed_block, context)?;
     }
-    let block = &mut signed_block.message;
+    let block = &signed_block.message;
     process_block(state, block, context)?;
     if validate_result && block.state_root != state.hash_tree_root()? {
         Err(Error::InvalidStateRoot)
@@ -104,7 +104,7 @@ pub fn state_transition<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    signed_block: &mut SignedBeaconBlock<
+    signed_block: &SignedBeaconBlock<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,

--- a/ethereum-consensus/src/capella/block_processing.rs
+++ b/ethereum-consensus/src/capella/block_processing.rs
@@ -43,10 +43,10 @@ pub fn process_bls_to_execution_change<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    signed_address_change: &mut SignedBlsToExecutionChange,
+    signed_address_change: &SignedBlsToExecutionChange,
     context: &Context,
 ) -> Result<()> {
-    let address_change = &mut signed_address_change.message;
+    let address_change = &signed_address_change.message;
     let signature = &signed_address_change.signature;
 
     if address_change.validator_index >= state.validators.len() {
@@ -121,7 +121,7 @@ pub fn process_operations<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    body: &mut BeaconBlockBody<
+    body: &BeaconBlockBody<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -151,18 +151,16 @@ pub fn process_operations<
         )))
     }
     body.proposer_slashings
-        .iter_mut()
+        .iter()
         .try_for_each(|op| process_proposer_slashing(state, op, context))?;
     body.attester_slashings
-        .iter_mut()
+        .iter()
         .try_for_each(|op| process_attester_slashing(state, op, context))?;
     body.attestations.iter().try_for_each(|op| process_attestation(state, op, context))?;
-    body.deposits.iter_mut().try_for_each(|op| process_deposit(state, op, context))?;
-    body.voluntary_exits
-        .iter_mut()
-        .try_for_each(|op| process_voluntary_exit(state, op, context))?;
+    body.deposits.iter().try_for_each(|op| process_deposit(state, op, context))?;
+    body.voluntary_exits.iter().try_for_each(|op| process_voluntary_exit(state, op, context))?;
     body.bls_to_execution_changes
-        .iter_mut()
+        .iter()
         .try_for_each(|op| process_bls_to_execution_change(state, op, context))?;
     Ok(())
 }
@@ -200,7 +198,7 @@ pub fn process_execution_payload<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    block: &mut BeaconBlockBody<
+    block: &BeaconBlockBody<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -217,7 +215,7 @@ pub fn process_execution_payload<
     >,
     context: &Context,
 ) -> Result<()> {
-    let payload = &mut block.execution_payload;
+    let payload = &block.execution_payload;
 
     let parent_hash_invalid =
         payload.parent_hash != state.latest_execution_payload_header.block_hash;
@@ -447,7 +445,7 @@ pub fn process_block<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    block: &mut BeaconBlock<
+    block: &BeaconBlock<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -466,10 +464,10 @@ pub fn process_block<
 ) -> Result<()> {
     process_block_header(state, block, context)?;
     process_withdrawals(state, &block.body.execution_payload, context)?;
-    process_execution_payload(state, &mut block.body, context)?;
+    process_execution_payload(state, &block.body, context)?;
     process_randao(state, &block.body, context)?;
     process_eth1_data(state, &block.body, context);
-    process_operations(state, &mut block.body, context)?;
+    process_operations(state, &block.body, context)?;
     process_sync_aggregate(state, &block.body.sync_aggregate, context)?;
     Ok(())
 }

--- a/ethereum-consensus/src/capella/execution_payload.rs
+++ b/ethereum-consensus/src/capella/execution_payload.rs
@@ -94,7 +94,7 @@ impl<
         const MAX_WITHDRAWALS_PER_PAYLOAD: usize,
     >
     TryFrom<
-        &'a mut ExecutionPayload<
+        &'a ExecutionPayload<
             BYTES_PER_LOGS_BLOOM,
             MAX_EXTRA_DATA_BYTES,
             MAX_BYTES_PER_TRANSACTION,
@@ -106,7 +106,7 @@ impl<
     type Error = Error;
 
     fn try_from(
-        payload: &'a mut ExecutionPayload<
+        payload: &'a ExecutionPayload<
             BYTES_PER_LOGS_BLOOM,
             MAX_EXTRA_DATA_BYTES,
             MAX_BYTES_PER_TRANSACTION,

--- a/ethereum-consensus/src/capella/genesis.rs
+++ b/ethereum-consensus/src/capella/genesis.rs
@@ -31,7 +31,7 @@ pub fn initialize_beacon_state_from_eth1<
 >(
     eth1_block_hash: Hash32,
     eth1_timestamp: u64,
-    deposits: &mut [Deposit],
+    deposits: &[Deposit],
     execution_payload_header: Option<
         &ExecutionPayloadHeader<BYTES_PER_LOGS_BLOOM, MAX_EXTRA_DATA_BYTES>,
     >,
@@ -60,7 +60,7 @@ pub fn initialize_beacon_state_from_eth1<
         deposit_count: deposits.len() as u64,
         ..Default::default()
     };
-    let mut latest_block_body = BeaconBlockBody::<
+    let latest_block_body = BeaconBlockBody::<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -95,7 +95,7 @@ pub fn initialize_beacon_state_from_eth1<
     };
 
     let mut leaves = List::<DepositData, DEPOSIT_DATA_LIST_BOUND>::default();
-    for deposit in deposits.iter_mut() {
+    for deposit in deposits.iter() {
         leaves.push(deposit.data.clone());
         state.eth1_data.deposit_root = leaves.hash_tree_root()?;
         process_deposit(&mut state, deposit, context)?;

--- a/ethereum-consensus/src/deneb/blob_sidecar.rs
+++ b/ethereum-consensus/src/deneb/blob_sidecar.rs
@@ -50,7 +50,7 @@ pub fn verify_blob_sidecar_inclusion_proof<
     const BYTES_PER_BLOB: usize,
     BlockBody: SimpleSerialize,
 >(
-    blob_sidecar: &mut BlobSidecar<BYTES_PER_BLOB, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH>,
+    blob_sidecar: &BlobSidecar<BYTES_PER_BLOB, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH>,
 ) -> Result<(), Error> {
     let path = &["blob_kzg_commitments".into(), blob_sidecar.index.into()];
     let g_index = BlockBody::generalized_index(path)?;
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn test_blob_sidecar_inclusion_proof_from_live_data() {
-        let mut blob_sidecar: spec::BlobSidecar = serde_json::from_str(BLOB_SIDECAR_JSON).unwrap();
+        let blob_sidecar: spec::BlobSidecar = serde_json::from_str(BLOB_SIDECAR_JSON).unwrap();
 
         let context = Context::for_sepolia();
         let kzg_settings = &context.kzg_settings;
@@ -131,7 +131,7 @@ mod tests {
             { spec::KZG_COMMITMENT_INCLUSION_PROOF_DEPTH },
             { spec::BYTES_PER_BLOB },
             spec::BeaconBlockBody,
-        >(&mut blob_sidecar)
+        >(&blob_sidecar)
         .is_ok());
     }
 }

--- a/ethereum-consensus/src/deneb/block_processing.rs
+++ b/ethereum-consensus/src/deneb/block_processing.rs
@@ -103,7 +103,7 @@ pub fn process_attestation<
         get_attestation_participation_flag_indices(state, data, inclusion_delay, context)?;
     is_valid_indexed_attestation(
         state,
-        &mut get_indexed_attestation(state, attestation, context)?,
+        &get_indexed_attestation(state, attestation, context)?,
         context,
     )?;
     let attesting_indices =
@@ -169,7 +169,7 @@ pub fn process_execution_payload<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    body: &mut BeaconBlockBody<
+    body: &BeaconBlockBody<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -187,7 +187,7 @@ pub fn process_execution_payload<
     >,
     context: &Context,
 ) -> Result<()> {
-    let payload = &mut body.execution_payload;
+    let payload = &body.execution_payload;
 
     let parent_hash_invalid =
         payload.parent_hash != state.latest_execution_payload_header.block_hash;
@@ -292,10 +292,10 @@ pub fn process_voluntary_exit<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    signed_voluntary_exit: &mut SignedVoluntaryExit,
+    signed_voluntary_exit: &SignedVoluntaryExit,
     context: &Context,
 ) -> Result<()> {
-    let voluntary_exit = &mut signed_voluntary_exit.message;
+    let voluntary_exit = &signed_voluntary_exit.message;
     let validator = state.validators.get(voluntary_exit.validator_index).ok_or_else(|| {
         invalid_operation_error(InvalidOperation::VoluntaryExit(
             InvalidVoluntaryExit::InvalidIndex(voluntary_exit.validator_index),
@@ -381,7 +381,7 @@ pub fn process_block<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    block: &mut BeaconBlock<
+    block: &BeaconBlock<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -401,10 +401,10 @@ pub fn process_block<
 ) -> Result<()> {
     process_block_header(state, block, context)?;
     process_withdrawals(state, &block.body.execution_payload, context)?;
-    process_execution_payload(state, &mut block.body, context)?;
+    process_execution_payload(state, &block.body, context)?;
     process_randao(state, &block.body, context)?;
     process_eth1_data(state, &block.body, context);
-    process_operations(state, &mut block.body, context)?;
+    process_operations(state, &block.body, context)?;
     process_sync_aggregate(state, &block.body.sync_aggregate, context)?;
     Ok(())
 }

--- a/ethereum-consensus/src/deneb/execution_payload.rs
+++ b/ethereum-consensus/src/deneb/execution_payload.rs
@@ -84,7 +84,7 @@ impl<
         const MAX_WITHDRAWALS_PER_PAYLOAD: usize,
     >
     TryFrom<
-        &'a mut ExecutionPayload<
+        &'a ExecutionPayload<
             BYTES_PER_LOGS_BLOOM,
             MAX_EXTRA_DATA_BYTES,
             MAX_BYTES_PER_TRANSACTION,
@@ -96,7 +96,7 @@ impl<
     type Error = Error;
 
     fn try_from(
-        payload: &'a mut ExecutionPayload<
+        payload: &'a ExecutionPayload<
             BYTES_PER_LOGS_BLOOM,
             MAX_EXTRA_DATA_BYTES,
             MAX_BYTES_PER_TRANSACTION,

--- a/ethereum-consensus/src/deneb/genesis.rs
+++ b/ethereum-consensus/src/deneb/genesis.rs
@@ -32,7 +32,7 @@ pub fn initialize_beacon_state_from_eth1<
 >(
     eth1_block_hash: Hash32,
     eth1_timestamp: u64,
-    deposits: &mut [Deposit],
+    deposits: &[Deposit],
     execution_payload_header: Option<
         &ExecutionPayloadHeader<BYTES_PER_LOGS_BLOOM, MAX_EXTRA_DATA_BYTES>,
     >,
@@ -61,7 +61,7 @@ pub fn initialize_beacon_state_from_eth1<
         deposit_count: deposits.len() as u64,
         ..Default::default()
     };
-    let mut latest_block_body = BeaconBlockBody::<
+    let latest_block_body = BeaconBlockBody::<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -97,7 +97,7 @@ pub fn initialize_beacon_state_from_eth1<
     };
 
     let mut leaves = List::<DepositData, DEPOSIT_DATA_LIST_BOUND>::default();
-    for deposit in deposits.iter_mut() {
+    for deposit in deposits.iter() {
         leaves.push(deposit.data.clone());
         state.eth1_data.deposit_root = leaves.hash_tree_root()?;
         process_deposit(&mut state, deposit, context)?;

--- a/ethereum-consensus/src/deneb/spec/mod.rs
+++ b/ethereum-consensus/src/deneb/spec/mod.rs
@@ -117,10 +117,10 @@ pub fn process_bls_to_execution_change<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    signed_address_change: &mut SignedBlsToExecutionChange,
+    signed_address_change: &SignedBlsToExecutionChange,
     context: &Context,
 ) -> Result<()> {
-    let address_change = &mut signed_address_change.message;
+    let address_change = &signed_address_change.message;
     let signature = &signed_address_change.signature;
     if address_change.validator_index >= state.validators.len() {
         return Err(invalid_operation_error(InvalidOperation::BlsToExecutionChange(
@@ -187,7 +187,7 @@ pub fn process_operations<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    body: &mut BeaconBlockBody<
+    body: &BeaconBlockBody<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -218,18 +218,16 @@ pub fn process_operations<
         )));
     }
     body.proposer_slashings
-        .iter_mut()
+        .iter()
         .try_for_each(|op| process_proposer_slashing(state, op, context))?;
     body.attester_slashings
-        .iter_mut()
+        .iter()
         .try_for_each(|op| process_attester_slashing(state, op, context))?;
     body.attestations.iter().try_for_each(|op| process_attestation(state, op, context))?;
-    body.deposits.iter_mut().try_for_each(|op| process_deposit(state, op, context))?;
-    body.voluntary_exits
-        .iter_mut()
-        .try_for_each(|op| process_voluntary_exit(state, op, context))?;
+    body.deposits.iter().try_for_each(|op| process_deposit(state, op, context))?;
+    body.voluntary_exits.iter().try_for_each(|op| process_voluntary_exit(state, op, context))?;
     body.bls_to_execution_changes
-        .iter_mut()
+        .iter()
         .try_for_each(|op| process_bls_to_execution_change(state, op, context))?;
     Ok(())
 }
@@ -438,8 +436,8 @@ pub fn process_sync_aggregate<
         Some(compute_epoch_at_slot(previous_slot, context)),
         context,
     )?;
-    let mut root_at_slot = *get_block_root_at_slot(state, previous_slot)?;
-    let signing_root = compute_signing_root(&mut root_at_slot, domain)?;
+    let root_at_slot = *get_block_root_at_slot(state, previous_slot)?;
+    let signing_root = compute_signing_root(&root_at_slot, domain)?;
     if eth_fast_aggregate_verify(
         participant_public_keys.as_slice(),
         signing_root.as_ref(),
@@ -510,7 +508,7 @@ pub fn process_proposer_slashing<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    proposer_slashing: &mut ProposerSlashing,
+    proposer_slashing: &ProposerSlashing,
     context: &Context,
 ) -> Result<()> {
     let header_1 = &proposer_slashing.signed_header_1.message;
@@ -546,10 +544,8 @@ pub fn process_proposer_slashing<
     }
     let epoch = compute_epoch_at_slot(header_1.slot, context);
     let domain = get_domain(state, DomainType::BeaconProposer, Some(epoch), context)?;
-    for signed_header in
-        [&mut proposer_slashing.signed_header_1, &mut proposer_slashing.signed_header_2]
-    {
-        let signing_root = compute_signing_root(&mut signed_header.message, domain)?;
+    for signed_header in [&proposer_slashing.signed_header_1, &proposer_slashing.signed_header_2] {
+        let signing_root = compute_signing_root(&signed_header.message, domain)?;
         let public_key = &proposer.public_key;
         if verify_signature(public_key, signing_root.as_ref(), &signed_header.signature).is_err() {
             return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
@@ -583,11 +579,11 @@ pub fn process_attester_slashing<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    attester_slashing: &mut AttesterSlashing<MAX_VALIDATORS_PER_COMMITTEE>,
+    attester_slashing: &AttesterSlashing<MAX_VALIDATORS_PER_COMMITTEE>,
     context: &Context,
 ) -> Result<()> {
-    let attestation_1 = &mut attester_slashing.attestation_1;
-    let attestation_2 = &mut attester_slashing.attestation_2;
+    let attestation_1 = &attester_slashing.attestation_1;
+    let attestation_2 = &attester_slashing.attestation_2;
     if !is_slashable_attestation_data(&attestation_1.data, &attestation_2.data) {
         return Err(invalid_operation_error(InvalidOperation::AttesterSlashing(
             InvalidAttesterSlashing::NotSlashable(
@@ -654,13 +650,13 @@ pub fn apply_deposit<
         increase_balance(state, index, amount);
         return Ok(());
     }
-    let mut deposit_message = DepositMessage {
+    let deposit_message = DepositMessage {
         public_key: public_key.clone(),
         withdrawal_credentials: withdrawal_credentials.clone(),
         amount,
     };
     let domain = compute_domain(DomainType::Deposit, None, None, context)?;
-    let signing_root = compute_signing_root(&mut deposit_message, domain)?;
+    let signing_root = compute_signing_root(&deposit_message, domain)?;
     if verify_signature(public_key, signing_root.as_ref(), signature).is_err() {
         return Ok(());
     }
@@ -697,7 +693,7 @@ pub fn process_deposit<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    deposit: &mut Deposit,
+    deposit: &Deposit,
     context: &Context,
 ) -> Result<()> {
     let leaf = deposit.data.hash_tree_root()?;
@@ -751,7 +747,7 @@ pub fn process_block_header<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    block: &mut BeaconBlock<
+    block: &BeaconBlock<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -860,11 +856,11 @@ pub fn process_randao<
     >,
     context: &Context,
 ) -> Result<()> {
-    let mut epoch = get_current_epoch(state, context);
+    let epoch = get_current_epoch(state, context);
     let proposer_index = get_beacon_proposer_index(state, context)?;
     let proposer = &state.validators[proposer_index];
     let domain = get_domain(state, DomainType::Randao, Some(epoch), context)?;
-    let signing_root = compute_signing_root(&mut epoch, domain)?;
+    let signing_root = compute_signing_root(&epoch, domain)?;
     if verify_signature(&proposer.public_key, signing_root.as_ref(), &body.randao_reveal).is_err() {
         return Err(invalid_operation_error(InvalidOperation::Randao(body.randao_reveal.clone())));
     }
@@ -1464,7 +1460,7 @@ pub fn process_historical_roots_update<
     let next_epoch = get_current_epoch(state, context) + 1;
     let epochs_per_historical_root = context.slots_per_historical_root / context.slots_per_epoch;
     if next_epoch % epochs_per_historical_root == 0 {
-        let mut historical_batch = HistoricalSummary {
+        let historical_batch = HistoricalSummary {
             block_summary_root: state.block_roots.hash_tree_root()?,
             state_summary_root: state.state_roots.hash_tree_root()?,
         };
@@ -1676,7 +1672,7 @@ pub fn get_genesis_block<
     const MAX_BLS_TO_EXECUTION_CHANGES: usize,
     const MAX_BLOB_COMMITMENTS_PER_BLOCK: usize,
 >(
-    genesis_state: &mut BeaconState<
+    genesis_state: &BeaconState<
         SLOTS_PER_HISTORICAL_ROOT,
         HISTORICAL_ROOTS_LIMIT,
         ETH1_DATA_VOTES_BOUND,
@@ -2252,7 +2248,7 @@ pub fn is_valid_indexed_attestation<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    indexed_attestation: &mut IndexedAttestation<MAX_VALIDATORS_PER_COMMITTEE>,
+    indexed_attestation: &IndexedAttestation<MAX_VALIDATORS_PER_COMMITTEE>,
     context: &Context,
 ) -> Result<()> {
     let attesting_indices = &indexed_attestation.attesting_indices;
@@ -2294,7 +2290,7 @@ pub fn is_valid_indexed_attestation<
         Some(indexed_attestation.data.target.epoch),
         context,
     )?;
-    let signing_root = compute_signing_root(&mut indexed_attestation.data, domain)?;
+    let signing_root = compute_signing_root(&indexed_attestation.data, domain)?;
     fast_aggregate_verify(&public_keys, signing_root.as_ref(), &indexed_attestation.signature)
         .map_err(Into::into)
 }
@@ -2332,7 +2328,7 @@ pub fn verify_block_signature<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    signed_block: &mut SignedBeaconBlock<
+    signed_block: &SignedBeaconBlock<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -2356,7 +2352,7 @@ pub fn verify_block_signature<
         .get(proposer_index)
         .ok_or(Error::OutOfBounds { requested: proposer_index, bound: state.validators.len() })?;
     let domain = get_domain(state, DomainType::BeaconProposer, None, context)?;
-    let signing_root = compute_signing_root(&mut signed_block.message, domain)?;
+    let signing_root = compute_signing_root(&signed_block.message, domain)?;
     let public_key = &proposer.public_key;
     verify_signature(public_key, signing_root.as_ref(), &signed_block.signature).map_err(Into::into)
 }
@@ -3264,7 +3260,7 @@ pub fn state_transition_block_in_slot<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    signed_block: &mut SignedBeaconBlock<
+    signed_block: &SignedBeaconBlock<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -3290,7 +3286,7 @@ pub fn state_transition_block_in_slot<
     if validate_result {
         verify_block_signature(state, signed_block, context)?;
     }
-    let block = &mut signed_block.message;
+    let block = &signed_block.message;
     process_block(state, block, context)?;
     if validate_result && block.state_root != state.hash_tree_root()? {
         Err(Error::InvalidStateRoot)
@@ -3332,7 +3328,7 @@ pub fn state_transition<
         BYTES_PER_LOGS_BLOOM,
         MAX_EXTRA_DATA_BYTES,
     >,
-    signed_block: &mut SignedBeaconBlock<
+    signed_block: &SignedBeaconBlock<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,

--- a/ethereum-consensus/src/electra/execution_payload.rs
+++ b/ethereum-consensus/src/electra/execution_payload.rs
@@ -94,7 +94,7 @@ impl<
         const MAX_EXECUTION_LAYER_EXITS: usize,
     >
     TryFrom<
-        &'a mut ExecutionPayload<
+        &'a ExecutionPayload<
             BYTES_PER_LOGS_BLOOM,
             MAX_EXTRA_DATA_BYTES,
             MAX_BYTES_PER_TRANSACTION,
@@ -108,7 +108,7 @@ impl<
     type Error = Error;
 
     fn try_from(
-        payload: &'a mut ExecutionPayload<
+        payload: &'a ExecutionPayload<
             BYTES_PER_LOGS_BLOOM,
             MAX_EXTRA_DATA_BYTES,
             MAX_BYTES_PER_TRANSACTION,

--- a/ethereum-consensus/src/phase0/epoch_processing.rs
+++ b/ethereum-consensus/src/phase0/epoch_processing.rs
@@ -513,7 +513,7 @@ pub fn process_historical_roots_update<
     let next_epoch = get_current_epoch(state, context) + 1;
     let epochs_per_historical_root = context.slots_per_historical_root / context.slots_per_epoch;
     if next_epoch % epochs_per_historical_root == 0 {
-        let mut historical_batch = HistoricalSummary {
+        let historical_batch = HistoricalSummary {
             block_summary_root: state.block_roots.hash_tree_root()?,
             state_summary_root: state.state_roots.hash_tree_root()?,
         };

--- a/ethereum-consensus/src/phase0/genesis.rs
+++ b/ethereum-consensus/src/phase0/genesis.rs
@@ -29,7 +29,7 @@ pub fn initialize_beacon_state_from_eth1<
 >(
     eth1_block_hash: Hash32,
     eth1_timestamp: u64,
-    deposits: &mut [Deposit],
+    deposits: &[Deposit],
     context: &Context,
 ) -> Result<
     BeaconState<
@@ -53,7 +53,7 @@ pub fn initialize_beacon_state_from_eth1<
         deposit_count: deposits.len() as u64,
         ..Default::default()
     };
-    let mut latest_block_body = BeaconBlockBody::<
+    let latest_block_body = BeaconBlockBody::<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -79,7 +79,7 @@ pub fn initialize_beacon_state_from_eth1<
     };
 
     let mut leaves = List::<DepositData, DEPOSIT_DATA_LIST_BOUND>::default();
-    for deposit in deposits.iter_mut() {
+    for deposit in deposits.iter() {
         leaves.push(deposit.data.clone());
         state.eth1_data.deposit_root = leaves.hash_tree_root()?;
         process_deposit(&mut state, deposit, context)?;
@@ -149,7 +149,7 @@ pub fn get_genesis_block<
     const MAX_DEPOSITS: usize,
     const MAX_VOLUNTARY_EXITS: usize,
 >(
-    genesis_state: &mut BeaconState<
+    genesis_state: &BeaconState<
         SLOTS_PER_HISTORICAL_ROOT,
         HISTORICAL_ROOTS_LIMIT,
         ETH1_DATA_VOTES_BOUND,

--- a/ethereum-consensus/src/phase0/helpers.rs
+++ b/ethereum-consensus/src/phase0/helpers.rs
@@ -88,7 +88,7 @@ pub fn is_valid_indexed_attestation<
         MAX_VALIDATORS_PER_COMMITTEE,
         PENDING_ATTESTATIONS_BOUND,
     >,
-    indexed_attestation: &mut IndexedAttestation<MAX_VALIDATORS_PER_COMMITTEE>,
+    indexed_attestation: &IndexedAttestation<MAX_VALIDATORS_PER_COMMITTEE>,
     context: &Context,
 ) -> Result<()> {
     let attesting_indices = &indexed_attestation.attesting_indices;
@@ -136,7 +136,7 @@ pub fn is_valid_indexed_attestation<
         Some(indexed_attestation.data.target.epoch),
         context,
     )?;
-    let signing_root = compute_signing_root(&mut indexed_attestation.data, domain)?;
+    let signing_root = compute_signing_root(&indexed_attestation.data, domain)?;
     fast_aggregate_verify(&public_keys, signing_root.as_ref(), &indexed_attestation.signature)
         .map_err(Into::into)
 }
@@ -166,7 +166,7 @@ pub fn verify_block_signature<
         MAX_VALIDATORS_PER_COMMITTEE,
         PENDING_ATTESTATIONS_BOUND,
     >,
-    signed_block: &mut SignedBeaconBlock<
+    signed_block: &SignedBeaconBlock<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -182,7 +182,7 @@ pub fn verify_block_signature<
         .get(proposer_index)
         .ok_or(Error::OutOfBounds { requested: proposer_index, bound: state.validators.len() })?;
     let domain = get_domain(state, DomainType::BeaconProposer, None, context)?;
-    let signing_root = compute_signing_root(&mut signed_block.message, domain)?;
+    let signing_root = compute_signing_root(&signed_block.message, domain)?;
 
     let public_key = &proposer.public_key;
     verify_signature(public_key, signing_root.as_ref(), &signed_block.signature).map_err(Into::into)

--- a/ethereum-consensus/src/phase0/state_transition.rs
+++ b/ethereum-consensus/src/phase0/state_transition.rs
@@ -37,7 +37,7 @@ pub fn state_transition_block_in_slot<
         MAX_VALIDATORS_PER_COMMITTEE,
         PENDING_ATTESTATIONS_BOUND,
     >,
-    signed_block: &mut SignedBeaconBlock<
+    signed_block: &SignedBeaconBlock<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -55,7 +55,7 @@ pub fn state_transition_block_in_slot<
     if validate_result {
         verify_block_signature(state, signed_block, context)?;
     }
-    let block = &mut signed_block.message;
+    let block = &signed_block.message;
     process_block(state, block, context)?;
     if validate_result && block.state_root != state.hash_tree_root()? {
         Err(Error::InvalidStateRoot)
@@ -89,7 +89,7 @@ pub fn state_transition<
         MAX_VALIDATORS_PER_COMMITTEE,
         PENDING_ATTESTATIONS_BOUND,
     >,
-    signed_block: &mut SignedBeaconBlock<
+    signed_block: &SignedBeaconBlock<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,

--- a/ethereum-consensus/src/signing.rs
+++ b/ethereum-consensus/src/signing.rs
@@ -12,17 +12,17 @@ pub struct SigningData {
 }
 
 pub fn compute_signing_root<T: HashTreeRoot>(
-    ssz_object: &mut T,
+    ssz_object: &T,
     domain: Domain,
 ) -> Result<Root, Error> {
     let object_root = ssz_object.hash_tree_root()?;
 
-    let mut s = SigningData { object_root, domain };
+    let s = SigningData { object_root, domain };
     s.hash_tree_root().map_err(Error::Merkleization)
 }
 
 pub fn sign_with_domain<T: HashTreeRoot>(
-    data: &mut T,
+    data: &T,
     signing_key: &SecretKey,
     domain: Domain,
 ) -> Result<BlsSignature, Error> {
@@ -31,7 +31,7 @@ pub fn sign_with_domain<T: HashTreeRoot>(
 }
 
 pub fn verify_signed_data<T: HashTreeRoot>(
-    data: &mut T,
+    data: &T,
     signature: &BlsSignature,
     public_key: &BlsPublicKey,
     domain: Domain,

--- a/ethereum-consensus/src/state_transition/executor.rs
+++ b/ethereum-consensus/src/state_transition/executor.rs
@@ -112,7 +112,7 @@ impl<
 
     pub fn apply_block(
         &mut self,
-        signed_block: &mut SignedBeaconBlock<
+        signed_block: &SignedBeaconBlock<
             MAX_PROPOSER_SLASHINGS,
             MAX_VALIDATORS_PER_COMMITTEE,
             MAX_ATTESTER_SLASHINGS,
@@ -134,7 +134,7 @@ impl<
 
     pub fn apply_block_with_validation(
         &mut self,
-        signed_block: &mut SignedBeaconBlock<
+        signed_block: &SignedBeaconBlock<
             MAX_PROPOSER_SLASHINGS,
             MAX_VALIDATORS_PER_COMMITTEE,
             MAX_ATTESTER_SLASHINGS,
@@ -173,7 +173,7 @@ impl<
 
     pub fn apply_phase0_block_with_validation(
         &mut self,
-        signed_block: &mut phase0::SignedBeaconBlock<
+        signed_block: &phase0::SignedBeaconBlock<
             MAX_PROPOSER_SLASHINGS,
             MAX_VALIDATORS_PER_COMMITTEE,
             MAX_ATTESTER_SLASHINGS,
@@ -196,7 +196,7 @@ impl<
 
     pub fn apply_altair_block_with_validation(
         &mut self,
-        signed_block: &mut altair::SignedBeaconBlock<
+        signed_block: &altair::SignedBeaconBlock<
             MAX_PROPOSER_SLASHINGS,
             MAX_VALIDATORS_PER_COMMITTEE,
             MAX_ATTESTER_SLASHINGS,
@@ -237,7 +237,7 @@ impl<
 
     pub fn apply_bellatrix_block_with_validation(
         &mut self,
-        signed_block: &mut bellatrix::SignedBeaconBlock<
+        signed_block: &bellatrix::SignedBeaconBlock<
             MAX_PROPOSER_SLASHINGS,
             MAX_VALIDATORS_PER_COMMITTEE,
             MAX_ATTESTER_SLASHINGS,
@@ -313,7 +313,7 @@ impl<
 
     pub fn apply_capella_block_with_validation(
         &mut self,
-        signed_block: &mut capella::SignedBeaconBlock<
+        signed_block: &capella::SignedBeaconBlock<
             MAX_PROPOSER_SLASHINGS,
             MAX_VALIDATORS_PER_COMMITTEE,
             MAX_ATTESTER_SLASHINGS,
@@ -409,7 +409,7 @@ impl<
 
     pub fn apply_deneb_block_with_validation(
         &mut self,
-        signed_block: &mut deneb::SignedBeaconBlock<
+        signed_block: &deneb::SignedBeaconBlock<
             MAX_PROPOSER_SLASHINGS,
             MAX_VALIDATORS_PER_COMMITTEE,
             MAX_ATTESTER_SLASHINGS,

--- a/ethereum-consensus/src/types/beacon_block.rs
+++ b/ethereum-consensus/src/types/beacon_block.rs
@@ -10,7 +10,7 @@ use crate::{
     types::beacon_block_body::{BeaconBlockBodyRef, BeaconBlockBodyRefMut},
     Fork as Version,
 };
-#[derive(Debug, Clone, PartialEq, Eq, SimpleSerialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serializable, HashTreeRoot, serde::Serialize)]
 #[ssz(transparent)]
 #[serde(untagged)]
 pub enum BeaconBlock<

--- a/ethereum-consensus/src/types/beacon_block_body.rs
+++ b/ethereum-consensus/src/types/beacon_block_body.rs
@@ -13,7 +13,7 @@ use crate::{
     types::execution_payload::{ExecutionPayloadRef, ExecutionPayloadRefMut},
     Fork as Version,
 };
-#[derive(Debug, Clone, PartialEq, Eq, SimpleSerialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serializable, HashTreeRoot, serde::Serialize)]
 #[ssz(transparent)]
 #[serde(untagged)]
 pub enum BeaconBlockBody<

--- a/ethereum-consensus/src/types/beacon_state.rs
+++ b/ethereum-consensus/src/types/beacon_state.rs
@@ -16,7 +16,7 @@ use crate::{
     types::execution_payload_header::{ExecutionPayloadHeaderRef, ExecutionPayloadHeaderRefMut},
     Fork as Version,
 };
-#[derive(Debug, Clone, PartialEq, Eq, SimpleSerialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serializable, HashTreeRoot, serde::Serialize)]
 #[ssz(transparent)]
 #[serde(untagged)]
 pub enum BeaconState<

--- a/ethereum-consensus/src/types/blinded_beacon_block.rs
+++ b/ethereum-consensus/src/types/blinded_beacon_block.rs
@@ -8,7 +8,7 @@ use crate::{
     types::blinded_beacon_block_body::{BlindedBeaconBlockBodyRef, BlindedBeaconBlockBodyRefMut},
     Fork as Version,
 };
-#[derive(Debug, Clone, PartialEq, Eq, SimpleSerialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serializable, HashTreeRoot, serde::Serialize)]
 #[ssz(transparent)]
 #[serde(untagged)]
 pub enum BlindedBeaconBlock<

--- a/ethereum-consensus/src/types/blinded_beacon_block_body.rs
+++ b/ethereum-consensus/src/types/blinded_beacon_block_body.rs
@@ -12,7 +12,7 @@ use crate::{
     types::execution_payload_header::{ExecutionPayloadHeaderRef, ExecutionPayloadHeaderRefMut},
     Fork as Version,
 };
-#[derive(Debug, Clone, PartialEq, Eq, SimpleSerialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serializable, HashTreeRoot, serde::Serialize)]
 #[ssz(transparent)]
 #[serde(untagged)]
 pub enum BlindedBeaconBlockBody<

--- a/ethereum-consensus/src/types/execution_payload.rs
+++ b/ethereum-consensus/src/types/execution_payload.rs
@@ -7,7 +7,7 @@ use crate::{
     ssz::prelude::*,
     Fork as Version,
 };
-#[derive(Debug, Clone, PartialEq, Eq, SimpleSerialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serializable, HashTreeRoot, serde::Serialize)]
 #[ssz(transparent)]
 #[serde(untagged)]
 pub enum ExecutionPayload<

--- a/ethereum-consensus/src/types/execution_payload_header.rs
+++ b/ethereum-consensus/src/types/execution_payload_header.rs
@@ -7,7 +7,7 @@ use crate::{
     ssz::prelude::*,
     Fork as Version,
 };
-#[derive(Debug, Clone, PartialEq, Eq, SimpleSerialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serializable, HashTreeRoot, serde::Serialize)]
 #[ssz(transparent)]
 #[serde(untagged)]
 pub enum ExecutionPayloadHeader<

--- a/ethereum-consensus/src/types/signed_beacon_block.rs
+++ b/ethereum-consensus/src/types/signed_beacon_block.rs
@@ -10,7 +10,7 @@ use crate::{
     types::beacon_block::{BeaconBlockRef, BeaconBlockRefMut},
     Fork as Version,
 };
-#[derive(Debug, Clone, PartialEq, Eq, SimpleSerialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serializable, HashTreeRoot, serde::Serialize)]
 #[ssz(transparent)]
 #[serde(untagged)]
 pub enum SignedBeaconBlock<

--- a/ethereum-consensus/src/types/signed_blinded_beacon_block.rs
+++ b/ethereum-consensus/src/types/signed_blinded_beacon_block.rs
@@ -8,7 +8,7 @@ use crate::{
     types::blinded_beacon_block::{BlindedBeaconBlockRef, BlindedBeaconBlockRefMut},
     Fork as Version,
 };
-#[derive(Debug, Clone, PartialEq, Eq, SimpleSerialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serializable, HashTreeRoot, serde::Serialize)]
 #[ssz(transparent)]
 #[serde(untagged)]
 pub enum SignedBlindedBeaconBlock<

--- a/justfile
+++ b/justfile
@@ -13,9 +13,9 @@ run-spec-tests filter="":
 fmt:
     cargo +nightly fmt --all
 lint: fmt
-    cargo +nightly clippy --all-targets --all-features
+    cargo +nightly clippy --all-targets --all-features --workspace
 build:
-    cargo build --all-targets --all-features
+    cargo build --all-targets --all-features --workspace
 run-ci: lint build test
 ec +command:
     cargo run -p ethereum-consensus --features ec {{command}}

--- a/spec-gen/src/generator.rs
+++ b/spec-gen/src/generator.rs
@@ -701,7 +701,6 @@ pub fn run() {
         Some(Fork::Bellatrix),
         Some(Fork::Capella),
         Some(Fork::Deneb),
-        Some(Fork::Electra),
     ];
 
     let mut specs = HashMap::<_, Rc<_>>::new();

--- a/spec-gen/src/type_generator.rs
+++ b/spec-gen/src/type_generator.rs
@@ -371,7 +371,7 @@ fn derive_type_defn(target_type: &Type, merge_type: &MergeType) -> (Item, Generi
         })
         .collect::<Vec<syn::Variant>>();
     let enum_defn = parse_quote! {
-        #[derive(Debug, Clone, PartialEq, Eq, SimpleSerialize, serde::Serialize)]
+        #[derive(Debug, Clone, PartialEq, Eq, Serializable, HashTreeRoot, serde::Serialize)]
         #[ssz(transparent)]
         #[serde(untagged)]
         pub enum #type_name #generics {

--- a/spec-tests/runners/genesis.rs
+++ b/spec-tests/runners/genesis.rs
@@ -71,7 +71,7 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                     gen_exec! {
                         test,
                         load_initialization_test,
-                        |(eth1, mut deposits, _, expected): (
+                        |(eth1, deposits, _, expected): (
                             Eth1,
                             Vec<spec::Deposit>,
                             Option<bool>,
@@ -95,7 +95,7 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                             >(
                                 eth1.eth1_block_hash,
                                 eth1.eth1_timestamp,
-                                &mut deposits,
+                                &deposits,
                                 context,
                             )
                             .unwrap();
@@ -111,7 +111,7 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                     gen_exec! {
                         test,
                         load_initialization_test,
-                        |(eth1, mut deposits, _, expected): (
+                        |(eth1, deposits, _, expected): (
                             Eth1,
                             Vec<spec::Deposit>,
                             Option<bool>,
@@ -135,7 +135,7 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                             >(
                                 eth1.eth1_block_hash,
                                 eth1.eth1_timestamp,
-                                &mut deposits,
+                                &deposits,
                                 context,
                             )
                             .unwrap();
@@ -151,7 +151,7 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                     gen_exec! {
                         test,
                         load_initialization_test,
-                        |(eth1, mut deposits, execution_payload_header, expected): (
+                        |(eth1, deposits, execution_payload_header, expected): (
                             Eth1,
                             Vec<spec::Deposit>,
                             Option<spec::ExecutionPayloadHeader>,
@@ -179,7 +179,7 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                             >(
                                 eth1.eth1_block_hash,
                                 eth1.eth1_timestamp,
-                                &mut deposits,
+                                &deposits,
                                 execution_payload_header.as_ref(),
                                 context,
                             )
@@ -196,7 +196,7 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                     gen_exec! {
                         test,
                         load_initialization_test,
-                        |(eth1, mut deposits, execution_payload_header, expected): (
+                        |(eth1, deposits, execution_payload_header, expected): (
                             Eth1,
                             Vec<spec::Deposit>,
                             Option<spec::ExecutionPayloadHeader>,
@@ -226,7 +226,7 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                             >(
                                 eth1.eth1_block_hash,
                                 eth1.eth1_timestamp,
-                                &mut deposits,
+                                &deposits,
                                 execution_payload_header.as_ref(),
                                 context,
                             )
@@ -243,7 +243,7 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                     gen_exec! {
                         test,
                         load_initialization_test,
-                        |(eth1, mut deposits, execution_payload_header, expected): (
+                        |(eth1, deposits, execution_payload_header, expected): (
                             Eth1,
                             Vec<spec::Deposit>,
                             Option<spec::ExecutionPayloadHeader>,
@@ -274,7 +274,7 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                             >(
                                 eth1.eth1_block_hash,
                                 eth1.eth1_timestamp,
-                                &mut deposits,
+                                &deposits,
                                 execution_payload_header.as_ref(),
                                 context,
                             )

--- a/spec-tests/runners/light_client.rs
+++ b/spec-tests/runners/light_client.rs
@@ -39,7 +39,7 @@ fn path_from(meta: &TestMeta) -> Vec<PathElement> {
     }
 }
 
-pub fn run_test<O: SimpleSerialize>(mut object: O, path: Path, proof: &Proof) -> Result<(), Error> {
+pub fn run_test<O: SimpleSerialize>(object: O, path: Path, proof: &Proof) -> Result<(), Error> {
     let root = object.hash_tree_root().unwrap();
     // test proof matches
     let (computed_proof, witness) = object.prove(path).expect("can prove");

--- a/spec-tests/runners/operations.rs
+++ b/spec-tests/runners/operations.rs
@@ -82,15 +82,14 @@ fn load_execution_payload_test<S: ssz_rs::Deserialize, O: ssz_rs::Deserialize>(
 fn run_test<S: Eq, O, F>(
     mut pre: S,
     post: Option<S>,
-    mut operation: O,
+    operation: O,
     context: &Context,
     exec_fn: F,
 ) -> Result<(), Error>
 where
-    F: FnOnce(&mut S, &mut O, &Context) -> Result<(), SpecError>,
+    F: FnOnce(&mut S, &O, &Context) -> Result<(), SpecError>,
 {
-    let operation = &mut operation;
-    let result = exec_fn(&mut pre, operation, context);
+    let result = exec_fn(&mut pre, &operation, context);
     if let Some(post) = post {
         assert!(result.is_ok());
         if pre != post {
@@ -112,7 +111,7 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                 test,
                 load_attestation_test,
                 |(pre, post, operation): (spec::BeaconState, Option<spec::BeaconState>, spec::Attestation), context| {
-                    run_test(pre, post, operation, context, |state, operation, context| { spec::process_attestation(state, &*operation, context)} )
+                    run_test(pre, post, operation, context, |state, operation, context| { spec::process_attestation(state, operation, context)} )
                 }
             }
         }
@@ -177,7 +176,7 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                         test,
                         load_sync_aggregate_test,
                         |(pre, post, operation): (spec::BeaconState, Option<spec::BeaconState>, spec::SyncAggregate), context| {
-                            run_test(pre, post, operation, context, |state, operation, context| { spec::process_sync_aggregate(state, &*operation, context)} )
+                            run_test(pre, post, operation, context, |state, operation, context| { spec::process_sync_aggregate(state, operation, context)} )
                         }
                     }
                 }
@@ -217,7 +216,7 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                         test,
                         load_withdrawals_test,
                         |(pre, post, operation): (spec::BeaconState, Option<spec::BeaconState>, spec::ExecutionPayload), context| {
-                            run_test(pre, post, operation, context, |state, operation, context| { spec::process_withdrawals(state, &*operation, context)} )
+                            run_test(pre, post, operation, context, |state, operation, context| { spec::process_withdrawals(state, operation, context)} )
                         }
                     }
                 }

--- a/spec-tests/runners/ssz_static.rs
+++ b/spec-tests/runners/ssz_static.rs
@@ -27,7 +27,7 @@ fn run_test<T: ssz_rs::SimpleSerialize>(
     (data, encoding): (RootData, Vec<u8>),
     _: &Context,
 ) -> Result<(), Error> {
-    let mut decoded_data: T = deserialize(&encoding).unwrap();
+    let decoded_data: T = deserialize(&encoding).unwrap();
     let serialized = serialize(&decoded_data).unwrap();
     let root = decoded_data.hash_tree_root().unwrap();
     assert_eq!(serialized, encoding);

--- a/spec-tests/runners/transition.rs
+++ b/spec-tests/runners/transition.rs
@@ -58,7 +58,7 @@ fn load_test<
     (pre, post, pre_blocks, post_blocks, meta)
 }
 
-fn set_fork_epochs(meta: &mut Meta, context: &mut Context) {
+fn set_fork_epochs(meta: &Meta, context: &mut Context) {
     context.altair_fork_epoch = Epoch::MAX;
     context.bellatrix_fork_epoch = Epoch::MAX;
     context.capella_fork_epoch = Epoch::MAX;
@@ -98,18 +98,18 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                     gen_exec! {
                         test,
                         load_test,
-                        | (pre, expected, pre_blocks, post_blocks, mut meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
+                        | (pre, expected, pre_blocks, post_blocks, meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
                             assert_eq!(meta.post_fork, "altair");
                             let mut context = context.clone();
-                            set_fork_epochs(&mut meta, &mut context);
+                            set_fork_epochs(&meta, &mut context);
                             let mut executor = state_transition::mainnet::Executor::new(BeaconState::Phase0(pre), context);
                             for block in pre_blocks.into_iter() {
-                                let mut block = SignedBeaconBlock::Phase0(block);
-                                executor.apply_block(&mut block)?;
+                                let block = SignedBeaconBlock::Phase0(block);
+                                executor.apply_block(&block)?;
                             }
                             for block in post_blocks.into_iter() {
-                                let mut block = SignedBeaconBlock::Altair(block);
-                                executor.apply_block(&mut block)?;
+                                let block = SignedBeaconBlock::Altair(block);
+                                executor.apply_block(&block)?;
                             }
                             let post = executor.state.altair().unwrap();
                             if post != &expected {
@@ -127,18 +127,18 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                     gen_exec! {
                         test,
                         load_test,
-                        | (pre, expected, pre_blocks, post_blocks, mut meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
+                        | (pre, expected, pre_blocks, post_blocks, meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
                             assert_eq!(meta.post_fork, "bellatrix");
                             let mut context = context.clone();
-                            set_fork_epochs(&mut meta, &mut context);
+                            set_fork_epochs(&meta, &mut context);
                             let mut executor = state_transition::mainnet::Executor::new(BeaconState::Altair(pre), context);
                             for block in pre_blocks.into_iter() {
-                                let mut block = SignedBeaconBlock::Altair(block);
-                                executor.apply_block(&mut block)?;
+                                let block = SignedBeaconBlock::Altair(block);
+                                executor.apply_block(&block)?;
                             }
                             for block in post_blocks.into_iter() {
-                                let mut block = SignedBeaconBlock::Bellatrix(block);
-                                executor.apply_block(&mut block)?;
+                                let block = SignedBeaconBlock::Bellatrix(block);
+                                executor.apply_block(&block)?;
                             }
                             let post = executor.state.bellatrix().unwrap();
                             if post != &expected {
@@ -156,18 +156,18 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                     gen_exec! {
                         test,
                         load_test,
-                        | (pre, expected, pre_blocks, post_blocks, mut meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
+                        | (pre, expected, pre_blocks, post_blocks, meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
                             assert_eq!(meta.post_fork, "capella");
                             let mut context = context.clone();
-                            set_fork_epochs(&mut meta, &mut context);
+                            set_fork_epochs(&meta, &mut context);
                             let mut executor = state_transition::mainnet::Executor::new(BeaconState::Bellatrix(pre), context);
                             for block in pre_blocks.into_iter() {
-                                let mut block = SignedBeaconBlock::Bellatrix(block);
-                                executor.apply_block(&mut block)?;
+                                let block = SignedBeaconBlock::Bellatrix(block);
+                                executor.apply_block(&block)?;
                             }
                             for block in post_blocks.into_iter() {
-                                let mut block = SignedBeaconBlock::Capella(block);
-                                executor.apply_block(&mut block)?;
+                                let block = SignedBeaconBlock::Capella(block);
+                                executor.apply_block(&block)?;
                             }
                             let post = executor.state.capella().unwrap();
                             if post != &expected {
@@ -185,18 +185,18 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                     gen_exec! {
                         test,
                         load_test,
-                        | (pre, expected, pre_blocks, post_blocks, mut meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
+                        | (pre, expected, pre_blocks, post_blocks, meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
                             assert_eq!(meta.post_fork, "deneb");
                             let mut context = context.clone();
-                            set_fork_epochs(&mut meta, &mut context);
+                            set_fork_epochs(&meta, &mut context);
                             let mut executor = state_transition::mainnet::Executor::new(BeaconState::Capella(pre), context);
                             for block in pre_blocks.into_iter() {
-                                let mut block = SignedBeaconBlock::Capella(block);
-                                executor.apply_block(&mut block)?;
+                                let block = SignedBeaconBlock::Capella(block);
+                                executor.apply_block(&block)?;
                             }
                             for block in post_blocks.into_iter() {
-                                let mut block = SignedBeaconBlock::Deneb(block);
-                                executor.apply_block(&mut block)?;
+                                let block = SignedBeaconBlock::Deneb(block);
+                                executor.apply_block(&block)?;
                             }
                             let post = executor.state.deneb().unwrap();
                             if post != &expected {
@@ -217,18 +217,18 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                     gen_exec! {
                         test,
                         load_test,
-                        | (pre, expected, pre_blocks, post_blocks, mut meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
+                        | (pre, expected, pre_blocks, post_blocks, meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
                             assert_eq!(meta.post_fork, "altair");
                             let mut context = context.clone();
-                            set_fork_epochs(&mut meta, &mut context);
+                            set_fork_epochs(&meta, &mut context);
                             let mut executor = state_transition::minimal::Executor::new(BeaconState::Phase0(pre), context);
                             for block in pre_blocks.into_iter() {
-                                let mut block = SignedBeaconBlock::Phase0(block);
-                                executor.apply_block(&mut block)?;
+                                let block = SignedBeaconBlock::Phase0(block);
+                                executor.apply_block(&block)?;
                             }
                             for block in post_blocks.into_iter() {
-                                let mut block = SignedBeaconBlock::Altair(block);
-                                executor.apply_block(&mut block)?;
+                                let block = SignedBeaconBlock::Altair(block);
+                                executor.apply_block(&block)?;
                             }
                             let post = executor.state.altair().unwrap();
                             if post != &expected {
@@ -246,18 +246,18 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                     gen_exec! {
                         test,
                         load_test,
-                        | (pre, expected, pre_blocks, post_blocks, mut meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
+                        | (pre, expected, pre_blocks, post_blocks, meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
                             assert_eq!(meta.post_fork, "bellatrix");
                             let mut context = context.clone();
-                            set_fork_epochs(&mut meta, &mut context);
+                            set_fork_epochs(&meta, &mut context);
                             let mut executor = state_transition::minimal::Executor::new(BeaconState::Altair(pre), context);
                             for block in pre_blocks.into_iter() {
-                                let mut block = SignedBeaconBlock::Altair(block);
-                                executor.apply_block(&mut block)?;
+                                let block = SignedBeaconBlock::Altair(block);
+                                executor.apply_block(&block)?;
                             }
                             for block in post_blocks.into_iter() {
-                                let mut block = SignedBeaconBlock::Bellatrix(block);
-                                executor.apply_block(&mut block)?;
+                                let block = SignedBeaconBlock::Bellatrix(block);
+                                executor.apply_block(&block)?;
                             }
                             let post = executor.state.bellatrix().unwrap();
                             if post != &expected {
@@ -275,18 +275,18 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                     gen_exec! {
                         test,
                         load_test,
-                        | (pre, expected, pre_blocks, post_blocks, mut meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
+                        | (pre, expected, pre_blocks, post_blocks, meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
                             assert_eq!(meta.post_fork, "capella");
                             let mut context = context.clone();
-                            set_fork_epochs(&mut meta, &mut context);
+                            set_fork_epochs(&meta, &mut context);
                             let mut executor = state_transition::minimal::Executor::new(BeaconState::Bellatrix(pre), context);
                             for block in pre_blocks.into_iter() {
-                                let mut block = SignedBeaconBlock::Bellatrix(block);
-                                executor.apply_block(&mut block)?;
+                                let block = SignedBeaconBlock::Bellatrix(block);
+                                executor.apply_block(&block)?;
                             }
                             for block in post_blocks.into_iter() {
-                                let mut block = SignedBeaconBlock::Capella(block);
-                                executor.apply_block(&mut block)?;
+                                let block = SignedBeaconBlock::Capella(block);
+                                executor.apply_block(&block)?;
                             }
                             let post = executor.state.capella().unwrap();
                             if post != &expected {
@@ -304,18 +304,18 @@ pub fn dispatch(test: &TestCase) -> Result<(), Error> {
                     gen_exec! {
                         test,
                         load_test,
-                        | (pre, expected, pre_blocks, post_blocks, mut meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
+                        | (pre, expected, pre_blocks, post_blocks, meta): (pre_spec::BeaconState, spec::BeaconState, Vec<pre_spec::SignedBeaconBlock>, Vec<spec::SignedBeaconBlock>, Meta), context: &Context| {
                             assert_eq!(meta.post_fork, "deneb");
                             let mut context = context.clone();
-                            set_fork_epochs(&mut meta, &mut context);
+                            set_fork_epochs(&meta, &mut context);
                             let mut executor = state_transition::minimal::Executor::new(BeaconState::Capella(pre), context);
                             for block in pre_blocks.into_iter() {
-                                let mut block = SignedBeaconBlock::Capella(block);
-                                executor.apply_block(&mut block)?;
+                                let block = SignedBeaconBlock::Capella(block);
+                                executor.apply_block(&block)?;
                             }
                             for block in post_blocks.into_iter() {
-                                let mut block = SignedBeaconBlock::Deneb(block);
-                                executor.apply_block(&mut block)?;
+                                let block = SignedBeaconBlock::Deneb(block);
+                                executor.apply_block(&block)?;
                             }
                             let post = executor.state.deneb().unwrap();
                             if post != &expected {


### PR DESCRIPTION
Some changes to proc-macros

Main thing is change to mutability of `HashTreeRoot::hash_tree_root`, which lets us drop `mut` in lots of places in the code