### PR TITLE
refactor `DEPOSIT_MERKLE_DEPTH` constant

### DIFF
--- a/ethereum-consensus/src/altair/block_processing.rs
+++ b/ethereum-consensus/src/altair/block_processing.rs
@@ -25,6 +25,7 @@ use crate::{
         invalid_operation_error, InvalidAttestation, InvalidDeposit, InvalidOperation,
         InvalidSyncAggregate,
     },
+    phase0::constants::DEPOSIT_CONTRACT_TREE_DEPTH,
     primitives::{BlsPublicKey, ParticipationFlags, ValidatorIndex},
     signing::compute_signing_root,
     ssz::prelude::*,
@@ -184,7 +185,7 @@ pub fn process_deposit<
 ) -> Result<()> {
     let leaf = deposit.data.hash_tree_root()?;
     let branch = &deposit.proof;
-    let depth = crate::phase0::block_processing::DEPOSIT_MERKLE_DEPTH;
+    let depth = DEPOSIT_CONTRACT_TREE_DEPTH + 1;
     let index = state.eth1_deposit_index as usize;
     let root = state.eth1_data.deposit_root;
     if is_valid_merkle_branch(leaf, branch, depth, index, root).is_err() {

--- a/ethereum-consensus/src/bellatrix/spec/mod.rs
+++ b/ethereum-consensus/src/bellatrix/spec/mod.rs
@@ -211,7 +211,7 @@ pub fn process_deposit<
 ) -> Result<()> {
     let leaf = deposit.data.hash_tree_root()?;
     let branch = &deposit.proof;
-    let depth = crate::phase0::block_processing::DEPOSIT_MERKLE_DEPTH;
+    let depth = DEPOSIT_CONTRACT_TREE_DEPTH + 1;
     let index = state.eth1_deposit_index as usize;
     let root = state.eth1_data.deposit_root;
     if is_valid_merkle_branch(leaf, branch, depth, index, root).is_err() {

--- a/ethereum-consensus/src/capella/spec/mod.rs
+++ b/ethereum-consensus/src/capella/spec/mod.rs
@@ -218,7 +218,7 @@ pub fn process_deposit<
 ) -> Result<()> {
     let leaf = deposit.data.hash_tree_root()?;
     let branch = &deposit.proof;
-    let depth = crate::phase0::block_processing::DEPOSIT_MERKLE_DEPTH;
+    let depth = DEPOSIT_CONTRACT_TREE_DEPTH + 1;
     let index = state.eth1_deposit_index as usize;
     let root = state.eth1_data.deposit_root;
     if is_valid_merkle_branch(leaf, branch, depth, index, root).is_err() {

--- a/ethereum-consensus/src/deneb/spec/mod.rs
+++ b/ethereum-consensus/src/deneb/spec/mod.rs
@@ -376,7 +376,7 @@ pub fn process_deposit<
 ) -> Result<()> {
     let leaf = deposit.data.hash_tree_root()?;
     let branch = &deposit.proof;
-    let depth = crate::phase0::block_processing::DEPOSIT_MERKLE_DEPTH;
+    let depth = DEPOSIT_CONTRACT_TREE_DEPTH + 1;
     let index = state.eth1_deposit_index as usize;
     let root = state.eth1_data.deposit_root;
     if is_valid_merkle_branch(leaf, branch, depth, index, root).is_err() {

--- a/ethereum-consensus/src/phase0/block_processing.rs
+++ b/ethereum-consensus/src/phase0/block_processing.rs
@@ -309,8 +309,6 @@ pub fn get_validator_from_deposit(deposit: &Deposit, context: &Context) -> Valid
     }
 }
 
-pub(crate) const DEPOSIT_MERKLE_DEPTH: usize = DEPOSIT_CONTRACT_TREE_DEPTH + 1;
-
 pub fn process_deposit<
     const SLOTS_PER_HISTORICAL_ROOT: usize,
     const HISTORICAL_ROOTS_LIMIT: usize,
@@ -336,17 +334,12 @@ pub fn process_deposit<
 ) -> Result<()> {
     let leaf = deposit.data.hash_tree_root()?;
     let branch = &deposit.proof;
+    let depth = DEPOSIT_CONTRACT_TREE_DEPTH + 1;
     let index = state.eth1_deposit_index as usize;
     let root = state.eth1_data.deposit_root;
-    if is_valid_merkle_branch(leaf, branch, DEPOSIT_MERKLE_DEPTH, index, root).is_err() {
+    if is_valid_merkle_branch(leaf, branch, depth, index, root).is_err() {
         return Err(invalid_operation_error(InvalidOperation::Deposit(
-            InvalidDeposit::InvalidProof {
-                leaf,
-                branch: branch.to_vec(),
-                depth: DEPOSIT_MERKLE_DEPTH,
-                index,
-                root,
-            },
+            InvalidDeposit::InvalidProof { leaf, branch: branch.to_vec(), depth, index, root },
         )))
     }
 


### PR DESCRIPTION
simplifies how this constant is used to avoid interactions with visibility and the spec generation