### PR TITLE
drop unnecessary `verify_signature`

### DIFF
--- a/ethereum-consensus/src/altair/spec/mod.rs
+++ b/ethereum-consensus/src/altair/spec/mod.rs
@@ -127,9 +127,10 @@ pub fn process_proposer_slashing<
     let epoch = compute_epoch_at_slot(header_1.slot, context);
     let domain = get_domain(state, DomainType::BeaconProposer, Some(epoch), context)?;
     for signed_header in [&proposer_slashing.signed_header_1, &proposer_slashing.signed_header_2] {
-        let signing_root = compute_signing_root(&signed_header.message, domain)?;
         let public_key = &proposer.public_key;
-        if verify_signature(public_key, signing_root.as_ref(), &signed_header.signature).is_err() {
+        if verify_signed_data(&signed_header.message, &signed_header.signature, public_key, domain)
+            .is_err()
+        {
             return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
                 InvalidProposerSlashing::InvalidSignature(signed_header.signature.clone()),
             )));
@@ -230,8 +231,7 @@ pub fn apply_deposit<
         amount,
     };
     let domain = compute_domain(DomainType::Deposit, None, None, context)?;
-    let signing_root = compute_signing_root(&deposit_message, domain)?;
-    if verify_signature(public_key, signing_root.as_ref(), signature).is_err() {
+    if verify_signed_data(&deposit_message, signature, public_key, domain).is_err() {
         return Ok(());
     }
     add_validator_to_registry(
@@ -466,8 +466,7 @@ pub fn process_randao<
     let proposer_index = get_beacon_proposer_index(state, context)?;
     let proposer = &state.validators[proposer_index];
     let domain = get_domain(state, DomainType::Randao, Some(epoch), context)?;
-    let signing_root = compute_signing_root(&epoch, domain)?;
-    if verify_signature(&proposer.public_key, signing_root.as_ref(), &body.randao_reveal).is_err() {
+    if verify_signed_data(&epoch, &body.randao_reveal, &proposer.public_key, domain).is_err() {
         return Err(invalid_operation_error(InvalidOperation::Randao(body.randao_reveal.clone())));
     }
     let mix = xor(get_randao_mix(state, epoch), &hash(body.randao_reveal.as_ref()));
@@ -1120,9 +1119,8 @@ pub fn verify_block_signature<
         .get(proposer_index)
         .ok_or(Error::OutOfBounds { requested: proposer_index, bound: state.validators.len() })?;
     let domain = get_domain(state, DomainType::BeaconProposer, None, context)?;
-    let signing_root = compute_signing_root(&signed_block.message, domain)?;
     let public_key = &proposer.public_key;
-    verify_signature(public_key, signing_root.as_ref(), &signed_block.signature).map_err(Into::into)
+    verify_signed_data(&signed_block.message, &signed_block.signature, public_key, domain)
 }
 pub fn get_domain<
     const SLOTS_PER_HISTORICAL_ROOT: usize,

--- a/ethereum-consensus/src/bellatrix/spec/mod.rs
+++ b/ethereum-consensus/src/bellatrix/spec/mod.rs
@@ -378,9 +378,10 @@ pub fn process_proposer_slashing<
     let epoch = compute_epoch_at_slot(header_1.slot, context);
     let domain = get_domain(state, DomainType::BeaconProposer, Some(epoch), context)?;
     for signed_header in [&proposer_slashing.signed_header_1, &proposer_slashing.signed_header_2] {
-        let signing_root = compute_signing_root(&signed_header.message, domain)?;
         let public_key = &proposer.public_key;
-        if verify_signature(public_key, signing_root.as_ref(), &signed_header.signature).is_err() {
+        if verify_signed_data(&signed_header.message, &signed_header.signature, public_key, domain)
+            .is_err()
+        {
             return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
                 InvalidProposerSlashing::InvalidSignature(signed_header.signature.clone()),
             )));
@@ -489,8 +490,7 @@ pub fn apply_deposit<
         amount,
     };
     let domain = compute_domain(DomainType::Deposit, None, None, context)?;
-    let signing_root = compute_signing_root(&deposit_message, domain)?;
-    if verify_signature(public_key, signing_root.as_ref(), signature).is_err() {
+    if verify_signed_data(&deposit_message, signature, public_key, domain).is_err() {
         return Ok(());
     }
     add_validator_to_registry(
@@ -753,8 +753,7 @@ pub fn process_randao<
     let proposer_index = get_beacon_proposer_index(state, context)?;
     let proposer = &state.validators[proposer_index];
     let domain = get_domain(state, DomainType::Randao, Some(epoch), context)?;
-    let signing_root = compute_signing_root(&epoch, domain)?;
-    if verify_signature(&proposer.public_key, signing_root.as_ref(), &body.randao_reveal).is_err() {
+    if verify_signed_data(&epoch, &body.randao_reveal, &proposer.public_key, domain).is_err() {
         return Err(invalid_operation_error(InvalidOperation::Randao(body.randao_reveal.clone())));
     }
     let mix = xor(get_randao_mix(state, epoch), &hash(body.randao_reveal.as_ref()));
@@ -2028,9 +2027,8 @@ pub fn verify_block_signature<
         .get(proposer_index)
         .ok_or(Error::OutOfBounds { requested: proposer_index, bound: state.validators.len() })?;
     let domain = get_domain(state, DomainType::BeaconProposer, None, context)?;
-    let signing_root = compute_signing_root(&signed_block.message, domain)?;
     let public_key = &proposer.public_key;
-    verify_signature(public_key, signing_root.as_ref(), &signed_block.signature).map_err(Into::into)
+    verify_signed_data(&signed_block.message, &signed_block.signature, public_key, domain)
 }
 pub fn get_domain<
     const SLOTS_PER_HISTORICAL_ROOT: usize,

--- a/ethereum-consensus/src/capella/spec/mod.rs
+++ b/ethereum-consensus/src/capella/spec/mod.rs
@@ -385,9 +385,10 @@ pub fn process_proposer_slashing<
     let epoch = compute_epoch_at_slot(header_1.slot, context);
     let domain = get_domain(state, DomainType::BeaconProposer, Some(epoch), context)?;
     for signed_header in [&proposer_slashing.signed_header_1, &proposer_slashing.signed_header_2] {
-        let signing_root = compute_signing_root(&signed_header.message, domain)?;
         let public_key = &proposer.public_key;
-        if verify_signature(public_key, signing_root.as_ref(), &signed_header.signature).is_err() {
+        if verify_signed_data(&signed_header.message, &signed_header.signature, public_key, domain)
+            .is_err()
+        {
             return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
                 InvalidProposerSlashing::InvalidSignature(signed_header.signature.clone()),
             )));
@@ -496,8 +497,7 @@ pub fn apply_deposit<
         amount,
     };
     let domain = compute_domain(DomainType::Deposit, None, None, context)?;
-    let signing_root = compute_signing_root(&deposit_message, domain)?;
-    if verify_signature(public_key, signing_root.as_ref(), signature).is_err() {
+    if verify_signed_data(&deposit_message, signature, public_key, domain).is_err() {
         return Ok(());
     }
     add_validator_to_registry(
@@ -768,8 +768,7 @@ pub fn process_randao<
     let proposer_index = get_beacon_proposer_index(state, context)?;
     let proposer = &state.validators[proposer_index];
     let domain = get_domain(state, DomainType::Randao, Some(epoch), context)?;
-    let signing_root = compute_signing_root(&epoch, domain)?;
-    if verify_signature(&proposer.public_key, signing_root.as_ref(), &body.randao_reveal).is_err() {
+    if verify_signed_data(&epoch, &body.randao_reveal, &proposer.public_key, domain).is_err() {
         return Err(invalid_operation_error(InvalidOperation::Randao(body.randao_reveal.clone())));
     }
     let mix = xor(get_randao_mix(state, epoch), &hash(body.randao_reveal.as_ref()));
@@ -2296,9 +2295,8 @@ pub fn verify_block_signature<
         .get(proposer_index)
         .ok_or(Error::OutOfBounds { requested: proposer_index, bound: state.validators.len() })?;
     let domain = get_domain(state, DomainType::BeaconProposer, None, context)?;
-    let signing_root = compute_signing_root(&signed_block.message, domain)?;
     let public_key = &proposer.public_key;
-    verify_signature(public_key, signing_root.as_ref(), &signed_block.signature).map_err(Into::into)
+    verify_signed_data(&signed_block.message, &signed_block.signature, public_key, domain)
 }
 pub fn get_domain<
     const SLOTS_PER_HISTORICAL_ROOT: usize,

--- a/ethereum-consensus/src/deneb/spec/mod.rs
+++ b/ethereum-consensus/src/deneb/spec/mod.rs
@@ -134,20 +134,19 @@ pub fn process_bls_to_execution_change<
             InvalidBlsToExecutionChange::WithdrawalCredentialsPrefix(withdrawal_credentials[0]),
         )));
     }
-    let domain = compute_domain(
-        DomainType::BlsToExecutionChange,
-        None,
-        Some(state.genesis_validators_root),
-        context,
-    )?;
-    let signing_root = compute_signing_root(address_change, domain)?;
     let public_key = &address_change.from_bls_public_key;
     if withdrawal_credentials[1..] != hash(public_key.as_ref())[1..] {
         return Err(invalid_operation_error(InvalidOperation::BlsToExecutionChange(
             InvalidBlsToExecutionChange::PublicKeyMismatch(public_key.clone()),
         )));
     }
-    verify_signature(public_key, signing_root.as_ref(), signature)?;
+    let domain = compute_domain(
+        DomainType::BlsToExecutionChange,
+        None,
+        Some(state.genesis_validators_root),
+        context,
+    )?;
+    verify_signed_data(address_change, signature, public_key, domain)?;
     withdrawal_credentials[0] = ETH1_ADDRESS_WITHDRAWAL_PREFIX;
     withdrawal_credentials[1..12].fill(0);
     withdrawal_credentials[12..].copy_from_slice(address_change.to_execution_address.as_ref());
@@ -545,9 +544,10 @@ pub fn process_proposer_slashing<
     let epoch = compute_epoch_at_slot(header_1.slot, context);
     let domain = get_domain(state, DomainType::BeaconProposer, Some(epoch), context)?;
     for signed_header in [&proposer_slashing.signed_header_1, &proposer_slashing.signed_header_2] {
-        let signing_root = compute_signing_root(&signed_header.message, domain)?;
         let public_key = &proposer.public_key;
-        if verify_signature(public_key, signing_root.as_ref(), &signed_header.signature).is_err() {
+        if verify_signed_data(&signed_header.message, &signed_header.signature, public_key, domain)
+            .is_err()
+        {
             return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
                 InvalidProposerSlashing::InvalidSignature(signed_header.signature.clone()),
             )));
@@ -656,8 +656,7 @@ pub fn apply_deposit<
         amount,
     };
     let domain = compute_domain(DomainType::Deposit, None, None, context)?;
-    let signing_root = compute_signing_root(&deposit_message, domain)?;
-    if verify_signature(public_key, signing_root.as_ref(), signature).is_err() {
+    if verify_signed_data(&deposit_message, signature, public_key, domain).is_err() {
         return Ok(());
     }
     add_validator_to_registry(
@@ -860,8 +859,7 @@ pub fn process_randao<
     let proposer_index = get_beacon_proposer_index(state, context)?;
     let proposer = &state.validators[proposer_index];
     let domain = get_domain(state, DomainType::Randao, Some(epoch), context)?;
-    let signing_root = compute_signing_root(&epoch, domain)?;
-    if verify_signature(&proposer.public_key, signing_root.as_ref(), &body.randao_reveal).is_err() {
+    if verify_signed_data(&epoch, &body.randao_reveal, &proposer.public_key, domain).is_err() {
         return Err(invalid_operation_error(InvalidOperation::Randao(body.randao_reveal.clone())));
     }
     let mix = xor(get_randao_mix(state, epoch), &hash(body.randao_reveal.as_ref()));
@@ -2352,9 +2350,8 @@ pub fn verify_block_signature<
         .get(proposer_index)
         .ok_or(Error::OutOfBounds { requested: proposer_index, bound: state.validators.len() })?;
     let domain = get_domain(state, DomainType::BeaconProposer, None, context)?;
-    let signing_root = compute_signing_root(&signed_block.message, domain)?;
     let public_key = &proposer.public_key;
-    verify_signature(public_key, signing_root.as_ref(), &signed_block.signature).map_err(Into::into)
+    verify_signed_data(&signed_block.message, &signed_block.signature, public_key, domain)
 }
 pub fn get_domain<
     const SLOTS_PER_HISTORICAL_ROOT: usize,

--- a/ethereum-consensus/src/electra/spec/mod.rs
+++ b/ethereum-consensus/src/electra/spec/mod.rs
@@ -310,20 +310,19 @@ pub fn process_bls_to_execution_change<
             InvalidBlsToExecutionChange::WithdrawalCredentialsPrefix(withdrawal_credentials[0]),
         )));
     }
-    let domain = compute_domain(
-        DomainType::BlsToExecutionChange,
-        None,
-        Some(state.genesis_validators_root),
-        context,
-    )?;
-    let signing_root = compute_signing_root(address_change, domain)?;
     let public_key = &address_change.from_bls_public_key;
     if withdrawal_credentials[1..] != hash(public_key.as_ref())[1..] {
         return Err(invalid_operation_error(InvalidOperation::BlsToExecutionChange(
             InvalidBlsToExecutionChange::PublicKeyMismatch(public_key.clone()),
         )));
     }
-    verify_signature(public_key, signing_root.as_ref(), signature)?;
+    let domain = compute_domain(
+        DomainType::BlsToExecutionChange,
+        None,
+        Some(state.genesis_validators_root),
+        context,
+    )?;
+    verify_signed_data(address_change, signature, public_key, domain)?;
     withdrawal_credentials[0] = ETH1_ADDRESS_WITHDRAWAL_PREFIX;
     withdrawal_credentials[1..12].fill(0);
     withdrawal_credentials[12..].copy_from_slice(address_change.to_execution_address.as_ref());
@@ -770,9 +769,10 @@ pub fn process_proposer_slashing<
     let epoch = compute_epoch_at_slot(header_1.slot, context);
     let domain = get_domain(state, DomainType::BeaconProposer, Some(epoch), context)?;
     for signed_header in [&proposer_slashing.signed_header_1, &proposer_slashing.signed_header_2] {
-        let signing_root = compute_signing_root(&signed_header.message, domain)?;
         let public_key = &proposer.public_key;
-        if verify_signature(public_key, signing_root.as_ref(), &signed_header.signature).is_err() {
+        if verify_signed_data(&signed_header.message, &signed_header.signature, public_key, domain)
+            .is_err()
+        {
             return Err(invalid_operation_error(InvalidOperation::ProposerSlashing(
                 InvalidProposerSlashing::InvalidSignature(signed_header.signature.clone()),
             )));
@@ -894,8 +894,7 @@ pub fn apply_deposit<
         amount,
     };
     let domain = compute_domain(DomainType::Deposit, None, None, context)?;
-    let signing_root = compute_signing_root(&deposit_message, domain)?;
-    if verify_signature(public_key, signing_root.as_ref(), signature).is_err() {
+    if verify_signed_data(&deposit_message, signature, public_key, domain).is_err() {
         return Ok(());
     }
     add_validator_to_registry(
@@ -1134,8 +1133,7 @@ pub fn process_randao<
     let proposer_index = get_beacon_proposer_index(state, context)?;
     let proposer = &state.validators[proposer_index];
     let domain = get_domain(state, DomainType::Randao, Some(epoch), context)?;
-    let signing_root = compute_signing_root(&epoch, domain)?;
-    if verify_signature(&proposer.public_key, signing_root.as_ref(), &body.randao_reveal).is_err() {
+    if verify_signed_data(&epoch, &body.randao_reveal, &proposer.public_key, domain).is_err() {
         return Err(invalid_operation_error(InvalidOperation::Randao(body.randao_reveal.clone())));
     }
     let mix = xor(get_randao_mix(state, epoch), &hash(body.randao_reveal.as_ref()));
@@ -2993,9 +2991,8 @@ pub fn verify_block_signature<
         .get(proposer_index)
         .ok_or(Error::OutOfBounds { requested: proposer_index, bound: state.validators.len() })?;
     let domain = get_domain(state, DomainType::BeaconProposer, None, context)?;
-    let signing_root = compute_signing_root(&signed_block.message, domain)?;
     let public_key = &proposer.public_key;
-    verify_signature(public_key, signing_root.as_ref(), &signed_block.signature).map_err(Into::into)
+    verify_signed_data(&signed_block.message, &signed_block.signature, public_key, domain)
 }
 pub fn get_domain<
     const SLOTS_PER_HISTORICAL_ROOT: usize,

--- a/ethereum-consensus/src/signing.rs
+++ b/ethereum-consensus/src/signing.rs
@@ -39,16 +39,3 @@ pub fn verify_signed_data<T: HashTreeRoot>(
     let signing_root = compute_signing_root(data, domain)?;
     crypto::verify_signature(public_key, signing_root.as_ref(), signature).map_err(Into::into)
 }
-
-// This function wraps the inner implementation defined in `crate::crypto` but presents a bit nicer
-// interface to users external to this crate.
-// NOTE: `verify_signed_data` serves a similar purpose but asking for a `&mut T` there
-// means that any message containing its public key (a common pattern in ethereum types)
-// needs to pass in a (ref to a) `clone` of the public key inside the message type.
-pub fn verify_signature(
-    public_key: &BlsPublicKey,
-    signing_root: &[u8],
-    signature: &BlsSignature,
-) -> Result<(), Error> {
-    crypto::verify_signature(public_key, signing_root, signature).map_err(Into::into)
-}


### PR DESCRIPTION
this function exists to help with mutability issues that mandated by the previous `HashTreeRoot` impl that demanded a `mut&` to the data to sign over

now that this requirement has  been removed, we can get rid of this function