### PR TITLE
use correct conversion methods mapping `c-kzg` types to local types

### DIFF
--- a/ethereum-consensus/src/deneb/polynomial_commitments.rs
+++ b/ethereum-consensus/src/deneb/polynomial_commitments.rs
@@ -81,7 +81,7 @@ pub fn compute_kzg_proof<const BYTES_PER_BLOB: usize>(
 
     let (proof, evaluation) =
         c_kzg::KzgProof::compute_kzg_proof(&blob, &evaluation_point, kzg_settings)?;
-    let proof = KzgProof::try_from(proof.to_bytes().as_ref()).expect("correct size");
+    let proof = KzgProof::try_from(proof.to_bytes().as_slice()).expect("correct size");
     let evaluation = FieldElement::try_from(evaluation.as_slice()).expect("correct size");
 
     let result = ProofAndEvaluation { proof, evaluation };
@@ -98,7 +98,7 @@ pub fn compute_blob_kzg_proof<const BYTES_PER_BLOB: usize>(
 
     let proof = c_kzg::KzgProof::compute_blob_kzg_proof(&blob, &commitment, kzg_settings)?;
 
-    Ok(KzgProof::try_from(proof.to_bytes().as_ref()).expect("input is correct size"))
+    Ok(KzgProof::try_from(proof.to_bytes().as_slice()).expect("input is correct size"))
 }
 
 pub fn verify_kzg_proof(


### PR DESCRIPTION
patching the cargo manifest to `v1.0.1` of `ethereum/c-kzg-4844` caused these build errors, and I am a little surprised why it was working in the first place actually..